### PR TITLE
[AUD-11] 애플 로그인 Redirection 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,9 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './login';

--- a/src/constants/login.ts
+++ b/src/constants/login.ts
@@ -1,0 +1,24 @@
+export const socialLoginProvider = {
+    apple: {
+        url: 'https://appleid.apple.com/auth/authorize',
+        config: {
+            client_id: import.meta.env.VITE_APPLE_CLIENT_ID,
+            redirect_uri: import.meta.env.VITE_APPLE_REDIRECT_URL,
+            response_type: 'code id_token',
+            state: 'origin:web',
+            scope: 'name email',
+            response_mode: 'form_post',
+            m: 11,
+            v: '1.5.4',
+            // TODO: 임시 속성들. 추후 논의 후 수정해야 함
+        },
+    },
+    kakao: {
+        url: 'https://kauth.kakao.com/oauth/authorize',
+        config: {
+            client_id: import.meta.env.VITE_KAKAO_CLIENT_ID,
+            redirect_uri: import.meta.env.VITE_KAKAO_REDIRECT_URL,
+            response_type: 'code',
+        },
+    },
+};

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,12 +1,13 @@
 export default function LoginPage() {
-    const KAKAO_REST_API_KEY = ''; // TODO: 임시 KEY
-    const KAKAO_REDIRECT_URI = 'http://localhost:5173/redirect'; // TODO: 임시 URL
-    const kakaoLoginLink = `https://kauth.kakao.com/oauth/authorize?client_id=${KAKAO_REST_API_KEY}&redirect_uri=${KAKAO_REDIRECT_URI}&response_type=code`;
+    const kakaoLoginLink = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.REACT_APP_KAKAO_REST_API_KEY}&redirect_uri=${process.env.REACT_APP_KAKAO_REDIRECTION_URL}&response_type=code`;
 
-    const handleLogin = () => (window.location.href = kakaoLoginLink);
+    const handleKakaoLogin = () => {
+        window.location.href = kakaoLoginLink;
+    };
+
     return (
         <div>
-            <button type="button" onClick={handleLogin}>
+            <button type="button" onClick={handleKakaoLogin}>
                 카카오로 로그인
             </button>
         </div>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,14 +1,43 @@
 export default function LoginPage() {
-    const kakaoLoginLink = `https://kauth.kakao.com/oauth/authorize?client_id=${process.env.REACT_APP_KAKAO_REST_API_KEY}&redirect_uri=${process.env.REACT_APP_KAKAO_REDIRECTION_URL}&response_type=code`;
-
-    const handleKakaoLogin = () => {
-        window.location.href = kakaoLoginLink;
+    const appleLoginConfig = {
+        client_id: import.meta.env.VITE_APPLE_LOGIN_CLIENT_ID as string,
+        redirect_uri: import.meta.env.VITE_APPLE_LOGIN_REDIRECT_URL as string,
+        response_type: 'code id_token',
+        state: 'origin:web',
+        scope: 'name email',
+        response_mode: 'form_post',
+        m: 11,
+        v: '1.5.4',
+        // TODO: 임시 속성들. 추후 논의 후 수정해야 함
     };
+
+    const kakaoLoginConfig = {
+        client_id: import.meta.env.VITE_KAKAO_REST_API_KEY as string,
+        redirect_uri: import.meta.env.VITE_KAKAO_REDIRECTION_URL as string,
+        response_type: 'code',
+    };
+
+    const makeQueryString = (
+        config: Record<string, string | number | boolean>,
+    ) => {
+        return Object.entries(config)
+            .map(([key, value]) => `${key}=${encodeURIComponent(value)}`)
+            .join('&');
+    };
+
+    const kakaoLoginLink = `https://kauth.kakao.com/oauth/authorize?${makeQueryString(kakaoLoginConfig)}`;
+    const appleLoginLink = `https://appleid.apple.com/auth/authorize?${makeQueryString(appleLoginConfig)}`;
+
+    const handleKakaoLogin = () => (window.location.href = kakaoLoginLink);
+    const handleAppleLogin = () => (window.location.href = appleLoginLink);
 
     return (
         <div>
             <button type="button" onClick={handleKakaoLogin}>
                 카카오로 로그인
+            </button>
+            <button type="button" onClick={handleAppleLogin}>
+                애플로 로그인
             </button>
         </div>
     );

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 export default function LoginPage() {
     const appleLoginConfig = {
-        client_id: import.meta.env.VITE_APPLE_LOGIN_CLIENT_ID as string,
-        redirect_uri: import.meta.env.VITE_APPLE_LOGIN_REDIRECT_URL as string,
+        client_id: import.meta.env.VITE_APPLE_CLIENT_ID as string,
+        redirect_uri: import.meta.env.VITE_APPLE_REDIRECT_URL as string,
         response_type: 'code id_token',
         state: 'origin:web',
         scope: 'name email',
@@ -12,7 +12,7 @@ export default function LoginPage() {
     };
 
     const kakaoLoginConfig = {
-        client_id: import.meta.env.VITE_KAKAO_REST_API_KEY as string,
+        client_id: import.meta.env.VITE_LOGIN_CLIENT_ID as string,
         redirect_uri: import.meta.env.VITE_KAKAO_REDIRECTION_URL as string,
         response_type: 'code',
     };

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,5 +1,5 @@
 export default function LoginPage() {
-    type SocialLoginProvider = 'apple' | 'kakao';
+    type SocialLoginProviderType = 'apple' | 'kakao';
 
     const socialLoginProvider = {
         apple: {
@@ -34,7 +34,7 @@ export default function LoginPage() {
             .join('&');
     };
 
-    const makeSocialLoginUrl = (provider: SocialLoginProvider) => {
+    const makeSocialLoginUrl = (provider: SocialLoginProviderType) => {
         const { url, config } = socialLoginProvider[provider];
         const queryString = makeQueryString(config);
 

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,30 +1,7 @@
+import { socialLoginProvider } from '@/constants';
+
 export default function LoginPage() {
     type SocialLoginProviderType = 'apple' | 'kakao';
-
-    const socialLoginProvider = {
-        apple: {
-            url: 'https://appleid.apple.com/auth/authorize',
-            config: {
-                client_id: import.meta.env.VITE_APPLE_CLIENT_ID,
-                redirect_uri: import.meta.env.VITE_APPLE_REDIRECT_URL,
-                response_type: 'code id_token',
-                state: 'origin:web',
-                scope: 'name email',
-                response_mode: 'form_post',
-                m: 11,
-                v: '1.5.4',
-                // TODO: 임시 속성들. 추후 논의 후 수정해야 함
-            },
-        },
-        kakao: {
-            url: 'https://kauth.kakao.com/oauth/authorize',
-            config: {
-                client_id: import.meta.env.VITE_KAKAO_CLIENT_ID,
-                redirect_uri: import.meta.env.VITE_KAKAO_REDIRECT_URL,
-                response_type: 'code',
-            },
-        },
-    };
 
     const makeQueryString = (
         config: Record<string, string | number | boolean>,

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,8 +1,7 @@
 import { socialLoginProvider } from '@/constants';
+import { SocialLoginProviderType } from '@/types';
 
 export default function LoginPage() {
-    type SocialLoginProviderType = 'apple' | 'kakao';
-
     const makeQueryString = (
         config: Record<string, string | number | boolean>,
     ) => {

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -1,20 +1,29 @@
 export default function LoginPage() {
-    const appleLoginConfig = {
-        client_id: import.meta.env.VITE_APPLE_CLIENT_ID as string,
-        redirect_uri: import.meta.env.VITE_APPLE_REDIRECT_URL as string,
-        response_type: 'code id_token',
-        state: 'origin:web',
-        scope: 'name email',
-        response_mode: 'form_post',
-        m: 11,
-        v: '1.5.4',
-        // TODO: 임시 속성들. 추후 논의 후 수정해야 함
-    };
+    type SocialLoginProvider = 'apple' | 'kakao';
 
-    const kakaoLoginConfig = {
-        client_id: import.meta.env.VITE_LOGIN_CLIENT_ID as string,
-        redirect_uri: import.meta.env.VITE_KAKAO_REDIRECTION_URL as string,
-        response_type: 'code',
+    const socialLoginProvider = {
+        apple: {
+            url: 'https://appleid.apple.com/auth/authorize',
+            config: {
+                client_id: import.meta.env.VITE_APPLE_CLIENT_ID as string,
+                redirect_uri: import.meta.env.VITE_APPLE_REDIRECT_URL as string,
+                response_type: 'code id_token',
+                state: 'origin:web',
+                scope: 'name email',
+                response_mode: 'form_post',
+                m: 11,
+                v: '1.5.4',
+                // TODO: 임시 속성들. 추후 논의 후 수정해야 함
+            },
+        },
+        kakao: {
+            url: 'https://kauth.kakao.com/oauth/authorize',
+            config: {
+                client_id: import.meta.env.VITE_KAKAO_CLIENT_ID as string,
+                redirect_uri: import.meta.env.VITE_KAKAO_REDIRECT_URL as string,
+                response_type: 'code',
+            },
+        },
     };
 
     const makeQueryString = (
@@ -25,11 +34,20 @@ export default function LoginPage() {
             .join('&');
     };
 
-    const kakaoLoginLink = `https://kauth.kakao.com/oauth/authorize?${makeQueryString(kakaoLoginConfig)}`;
-    const appleLoginLink = `https://appleid.apple.com/auth/authorize?${makeQueryString(appleLoginConfig)}`;
+    const makeSocialLoginUrl = (provider: SocialLoginProvider) => {
+        const { url, config } = socialLoginProvider[provider];
+        const queryString = makeQueryString(config);
 
-    const handleKakaoLogin = () => (window.location.href = kakaoLoginLink);
-    const handleAppleLogin = () => (window.location.href = appleLoginLink);
+        return `${url}?${queryString}`;
+    };
+
+    const handleKakaoLogin = () => {
+        window.location.href = makeSocialLoginUrl('kakao');
+    };
+
+    const handleAppleLogin = () => {
+        window.location.href = makeSocialLoginUrl('apple');
+    };
 
     return (
         <div>

--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -5,8 +5,8 @@ export default function LoginPage() {
         apple: {
             url: 'https://appleid.apple.com/auth/authorize',
             config: {
-                client_id: import.meta.env.VITE_APPLE_CLIENT_ID as string,
-                redirect_uri: import.meta.env.VITE_APPLE_REDIRECT_URL as string,
+                client_id: import.meta.env.VITE_APPLE_CLIENT_ID,
+                redirect_uri: import.meta.env.VITE_APPLE_REDIRECT_URL,
                 response_type: 'code id_token',
                 state: 'origin:web',
                 scope: 'name email',
@@ -19,8 +19,8 @@ export default function LoginPage() {
         kakao: {
             url: 'https://kauth.kakao.com/oauth/authorize',
             config: {
-                client_id: import.meta.env.VITE_KAKAO_CLIENT_ID as string,
-                redirect_uri: import.meta.env.VITE_KAKAO_REDIRECT_URL as string,
+                client_id: import.meta.env.VITE_KAKAO_CLIENT_ID,
+                redirect_uri: import.meta.env.VITE_KAKAO_REDIRECT_URL,
                 response_type: 'code',
             },
         },

--- a/src/pages/MainPage.tsx
+++ b/src/pages/MainPage.tsx
@@ -1,30 +1,16 @@
-import reactLogo from '@/assets/react.svg';
 import { useTmap } from '@/hooks/useTmap';
 
-import viteLogo from '/vite.svg';
-
 function MainPage() {
-
-    const { tmapModuleRef, mapContainerRef } = useTmap({
+    const { /*tmapModuleRef, */ mapContainerRef } = useTmap({
         mapId: 'tmap',
         latitude: 37.5652045,
         longitude: 126.98702028,
     });
 
     return (
-            <div>
-                <div ref={mapContainerRef} />
-                <a href="https://vitejs.dev" target="_blank">
-                    <img src={viteLogo} className="logo" alt="Vite logo" />
-                </a>
-                <a href="https://react.dev" target="_blank">
-                    <img
-                        src={reactLogo}
-                        className="logo react"
-                        alt="React logo"
-                    />
-                </a>
-            </div>
+        <div>
+            <div ref={mapContainerRef} />
+        </div>
     );
 }
 

--- a/src/pages/RedirectionPage.tsx
+++ b/src/pages/RedirectionPage.tsx
@@ -1,7 +1,0 @@
-export default function RedirectionPage() {
-    return (
-        <div>
-            <h1>Redirection Page</h1>
-        </div>
-    );
-}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './login';

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -1,0 +1,1 @@
+export type SocialLoginProviderType = 'apple' | 'kakao';

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -1,0 +1,6 @@
+interface ImportMetaEnv {
+    readonly VITE_KAKAO_CLIENT_ID: string;
+    readonly VITE_KAKAO_REDIRECTION_URL: string;
+    readonly VITE_APPLE_CLIENT_ID: string;
+    readonly VITE_APPLE_REDIRECT_URL: string;
+}

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -4,3 +4,7 @@ interface ImportMetaEnv {
     readonly VITE_APPLE_CLIENT_ID: string;
     readonly VITE_APPLE_REDIRECT_URL: string;
 }
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
### 📃 변경사항  
- 변수들 .env 파일로 이동
- 애플로그인 링크 추가
- 카카오 로그인과 애플로그인 쿼리들을 객체로 분리

### 🫨 고민한 부분
-  makeQueryString 함수의 config 파라미터의 타입을 어떻게 지정할지
- loginConfig의 속성 일부를 as string으로 강제하는게 맞을지

### 💫 기타사항 
![image](https://github.com/Nexters/audy-client/assets/80266418/1766a746-c6ed-4d12-94ff-4722ad88425a)
- 이렇게 말씀하신 부분에 대해서는 아직 저희 router 코드도 추가가 안되었고 백엔드와도 이야기가 되지 않아서 코드를 작성하지 않았습니다
   목요일 회의 이후에 작성하는 것이 좋을 것 같아서 두었는데 의견있으시면 말해주세요! 

- 그리고 애플은 잘 되는지 테스트를 못해봤습니다... 돈 나간다해서 ... .. 
   이후에 따로 지라 이슈 만들어서 코드 완벽하게 추가하고 확인하는게 좋을 것 같아요 

- 코드는 나중에 파일 분리할 것 같습니다

- 살짝 정신없는 상태로 코드를 작성햇네효,,, 