### PR TITLE
[AUD-24] infoWindow 생성 및 삭제 메서드 구현

### DIFF
--- a/src/features/index.ts
+++ b/src/features/index.ts
@@ -1,0 +1,1 @@
+export * from './map';

--- a/src/features/map/InfoWindow.tsx
+++ b/src/features/map/InfoWindow.tsx
@@ -1,0 +1,63 @@
+interface PropsType {
+    name: string;
+    address: string;
+    // isPinned: boolean;
+}
+
+export default function InfoWindow({
+    name,
+    address,
+    // isPinned,
+}: PropsType) {
+    // TODO: isPinned에 따라서 버튼 스타일 변경
+
+    return /* html */ `
+        <div style="${layoutStyle}">
+            <div>
+                <p style="${nameStyle} ${textStyle}">${name}</p>
+                <p style="${addressStyle} ${textStyle}">${address}</p>
+            </div>
+            <button style="${buttonStyle}"></button>
+     
+        </div>
+    `;
+}
+
+const layoutStyle = `
+    align-items: center;
+    background-color: white;
+    border: 1px solid #6B7280;
+    border-radius: 14px;
+    box-sizing: border-box;
+    display: flex;
+    justify-content: space-between;
+    padding: 18px 32px 16px 32px;
+    width: 338px;
+`;
+
+const textStyle = `
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    width: 230px;
+`;
+
+const nameStyle = `
+    color: #111827;
+    font-size: 18px;
+    font-weight: 700;
+    margin: 0 0 4px 0;
+`;
+
+const addressStyle = `
+    color: #9CA3AF;
+    font-size: 15px;
+    margin: 0px;
+`;
+
+const buttonStyle = `
+    background-color: white;
+    border: 1px solid #E5E7EB;
+    border-radius: 10px;
+    padding: 16px;
+`;

--- a/src/features/map/index.ts
+++ b/src/features/map/index.ts
@@ -1,0 +1,1 @@
+export * from './InfoWindow';

--- a/src/utils/tmap.ts
+++ b/src/utils/tmap.ts
@@ -210,20 +210,16 @@ export class TMapModule {
     }) {
         this.removeInfoWindow();
 
-        const content =
-            "<div style=' position: relative; border-bottom: 1px solid #dcdcdc; line-height: 18px; padding: 0 35px 2px 0;'>" +
-            "<div style='font-size: 12px; line-height: 15px;'>" +
-            "<span style='display: inline-block; width: 14px; height: 14px; background-image: url('/resources/images/common/footer_logo.png'); vertical-align: middle; margin-right: 5px;'></span>티맵 모빌리티" +
-            '</div>' +
-            '</div>' +
-            "<div style='position: relative; padding-top: 5px; display:inline-block'>" +
-            "<div style='display:inline-block; border:1px solid #dcdcdc;'><img src='/resources/images/common/footer_logo.png' width='90' height='70'></div>" +
-            "<div style='display:inline-block; margin-left:5px; vertical-align: top;'>" +
-            "<span style='font-size: 12px; margin-left:2px; margin-bottom:2px; display:block;'>서울 중구 삼일대로 343 (우)04538</span>" +
-            "<span style='font-size: 12px; color:#888; margin-left:2px; margin-bottom:2px; display:block;'>(지번) 저동1가 114</span>" +
-            "<span style='font-size: 12px; margin-left:2px;'><a href='https://openapi.sk.com/' target='blank'>개발자센터</a></span>" +
-            '</div>' +
-            '</div>';
+        const content = /*html*/ `
+        <div style="display: flex; align-items: center; gap: 24px;">
+            <div>
+                <p>${name}</p>
+                <p>${address}</p>
+            </div>
+            <div>
+                <button>핀</button>
+            </div>
+        </div>`; // TODO: 임시 디자인
 
         const infoWindow = new Tmapv3.InfoWindow({
             position: new Tmapv3.LatLng(latitude, longitude),

--- a/src/utils/tmap.ts
+++ b/src/utils/tmap.ts
@@ -27,6 +27,8 @@ export class TMapModule {
 
     #isPathVisible: boolean = true;
 
+    #infoWindows: (typeof window.Tmapv3.InfoWindow)[] = [];
+
     constructor({
         mapId = 'tmap',
         width = 640,
@@ -192,5 +194,46 @@ export class TMapModule {
         if (!this.#polylineList.length) return;
         this.#polylineList.forEach((polyline) => polyline.setMap(null));
         this.#polylineList = [];
+    }
+
+    // 인포창 생성
+    createInfoWindow({
+        latitude,
+        longitude,
+        name,
+        address,
+    }: {
+        latitude: number;
+        longitude: number;
+        name: string;
+        address: string;
+    }) {
+        this.#infoWindows.forEach((infoWindow) => infoWindow.setMap(null));
+
+        const content =
+            "<div style=' position: relative; border-bottom: 1px solid #dcdcdc; line-height: 18px; padding: 0 35px 2px 0;'>" +
+            "<div style='font-size: 12px; line-height: 15px;'>" +
+            "<span style='display: inline-block; width: 14px; height: 14px; background-image: url('/resources/images/common/footer_logo.png'); vertical-align: middle; margin-right: 5px;'></span>티맵 모빌리티" +
+            '</div>' +
+            '</div>' +
+            "<div style='position: relative; padding-top: 5px; display:inline-block'>" +
+            "<div style='display:inline-block; border:1px solid #dcdcdc;'><img src='/resources/images/common/footer_logo.png' width='90' height='70'></div>" +
+            "<div style='display:inline-block; margin-left:5px; vertical-align: top;'>" +
+            "<span style='font-size: 12px; margin-left:2px; margin-bottom:2px; display:block;'>서울 중구 삼일대로 343 (우)04538</span>" +
+            "<span style='font-size: 12px; color:#888; margin-left:2px; margin-bottom:2px; display:block;'>(지번) 저동1가 114</span>" +
+            "<span style='font-size: 12px; margin-left:2px;'><a href='https://openapi.sk.com/' target='blank'>개발자센터</a></span>" +
+            '</div>' +
+            '</div>';
+
+        const infoWindow = new Tmapv3.InfoWindow({
+            position: new Tmapv3.LatLng(latitude, longitude),
+            content,
+            map: this.#mapInstance,
+        });
+
+        infoWindow.setMap(this.#mapInstance);
+        this.#infoWindows.push(infoWindow);
+
+        this.#mapInstance.setCenter(new Tmapv3.LatLng(latitude, longitude));
     }
 }

--- a/src/utils/tmap.ts
+++ b/src/utils/tmap.ts
@@ -208,7 +208,7 @@ export class TMapModule {
         name: string;
         address: string;
     }) {
-        this.#infoWindows.forEach((infoWindow) => infoWindow.setMap(null));
+        this.removeInfoWindow();
 
         const content =
             "<div style=' position: relative; border-bottom: 1px solid #dcdcdc; line-height: 18px; padding: 0 35px 2px 0;'>" +
@@ -235,5 +235,10 @@ export class TMapModule {
         this.#infoWindows.push(infoWindow);
 
         this.#mapInstance.setCenter(new Tmapv3.LatLng(latitude, longitude));
+    }
+
+    // 인포창 삭제
+    removeInfoWindow() {
+        this.#infoWindows.forEach((infoWindow) => infoWindow.setMap(null));
     }
 }

--- a/src/utils/tmap.ts
+++ b/src/utils/tmap.ts
@@ -30,6 +30,8 @@ export class TMapModule {
 
     #infoWindows: (typeof window.Tmapv3.InfoWindow)[] = [];
 
+    #zoomInLevel: number = 17; // TODO: 임시
+
     constructor({
         mapId = 'tmap',
         width = 640,
@@ -88,7 +90,6 @@ export class TMapModule {
     // 마커 삭제
     removeMarker(markerIndex: number) {
         const targetMarker = this.#markers.splice(markerIndex, 1)[0];
-
         targetMarker.setMap(null);
     }
 
@@ -211,8 +212,9 @@ export class TMapModule {
     }) {
         this.removeInfoWindow();
 
+        const infoWindowLatLng = new Tmapv3.LatLng(latitude, longitude);
         const infoWindow = new Tmapv3.InfoWindow({
-            position: new Tmapv3.LatLng(latitude, longitude),
+            position: infoWindowLatLng,
             content: InfoWindow({ name, address }),
             type: 2,
             border: '0px',
@@ -223,8 +225,8 @@ export class TMapModule {
         infoWindow.setMap(this.#mapInstance);
         this.#infoWindows.push(infoWindow);
 
-        this.#mapInstance.setCenter(new Tmapv3.LatLng(latitude, longitude));
-        this.#mapInstance.setZoom(17);
+        this.#mapInstance.setCenter(infoWindowLatLng);
+        this.#mapInstance.setZoom(this.#zoomInLevel);
     }
 
     // 인포창 삭제

--- a/src/utils/tmap.ts
+++ b/src/utils/tmap.ts
@@ -86,7 +86,7 @@ export class TMapModule {
     }
 
     // 마커 삭제
-    removeMarker({ markerIndex }: { markerIndex: number }) {
+    removeMarker(markerIndex: number) {
         const targetMarker = this.#markers.splice(markerIndex, 1)[0];
 
         targetMarker.setMap(null);

--- a/src/utils/tmap.ts
+++ b/src/utils/tmap.ts
@@ -224,7 +224,7 @@ export class TMapModule {
         this.#infoWindows.push(infoWindow);
 
         this.#mapInstance.setCenter(new Tmapv3.LatLng(latitude, longitude));
-        // 줌인하기
+        this.#mapInstance.setZoom(17);
     }
 
     // 인포창 삭제

--- a/src/utils/tmap.ts
+++ b/src/utils/tmap.ts
@@ -83,22 +83,9 @@ export class TMapModule {
     }
 
     // 마커 삭제
-    removeMarker({
-        latitude,
-        longitude,
-    }: {
-        latitude: number;
-        longitude: number;
-    }) {
-        const targetMarkerIndex = this.#markers.findIndex(
-            (marker) =>
-                marker.getPosition().lat() === latitude &&
-                marker.getPosition().lng() === longitude,
-        );
+    removeMarker({ markerIndex }: { markerIndex: number }) {
+        const targetMarker = this.#markers.splice(markerIndex, 1)[0];
 
-        if (targetMarkerIndex === -1) return;
-
-        const targetMarker = this.#markers.splice(targetMarkerIndex, 1)[0];
         targetMarker.setMap(null);
     }
 

--- a/src/utils/tmap.ts
+++ b/src/utils/tmap.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { TmapRepository } from '@/apis/tmap';
+import InfoWindow from '@/features/map/InfoWindow';
 
 export interface TmapConstructorType {
     /** 지도를 렌더링할 HTMLDivElement 에 적용할 id */
@@ -210,20 +211,12 @@ export class TMapModule {
     }) {
         this.removeInfoWindow();
 
-        const content = /*html*/ `
-        <div style="display: flex; align-items: center; gap: 24px;">
-            <div>
-                <p>${name}</p>
-                <p>${address}</p>
-            </div>
-            <div>
-                <button>핀</button>
-            </div>
-        </div>`; // TODO: 임시 디자인
-
         const infoWindow = new Tmapv3.InfoWindow({
             position: new Tmapv3.LatLng(latitude, longitude),
-            content,
+            content: InfoWindow({ name, address }),
+            type: 2,
+            border: '0px',
+            background: 'none',
             map: this.#mapInstance,
         });
 
@@ -231,6 +224,7 @@ export class TMapModule {
         this.#infoWindows.push(infoWindow);
 
         this.#mapInstance.setCenter(new Tmapv3.LatLng(latitude, longitude));
+        // 줌인하기
     }
 
     // 인포창 삭제


### PR DESCRIPTION
### 📃 변경사항  
- 마커 삭제 메서드 파라미터를 lat, lng에서 index로 변경
  - 인덱스를 받아서 삭제할 수 있도록 처리
- 인포창 생성하는 메서드 구현
  - 이름, 주소, 위경도를 파라미터로 받음
  - 이전에 생성된 인포창을 모두 삭제한 뒤에 생성함 
  - 인포창이 생성되면 해당 위치로 지도가 이동, 줌인됨
- 인포창 컴포넌트 구현
  - 아직 디자인이 완성되지 않은 것 같아서 대충만 구성했습니다.
 
### 🫨 고민한 부분
- 인포창 컴포넌트를 어떻게 만들지
  - 인포창 내옹은 html 문자열 형태로 넘겨야합니다.
  - 인포창 컴포넌트를 일반적인 리액트 컴포넌트 형태로 생성했을 경우에 html 문자열로 변환하는 방법을 찾지 못했습니다..
  - 그래서 그냥 컴포넌트 자체를 문자열로 구성했습니다.
  - 좋은 방법이 있으면 알려주세요 

### 🎇 동작 화면
![image](https://github.com/Nexters/audy-client/assets/80266418/6dcecc5c-a69f-45cd-a4fd-9e703474ae75)


### 💫 기타사항
지도를 클릭했을 때 해당 위치에 인포창이 뜨도록 하는 것도 구현하고있었는데, 이 부분은 PR을 별도로 생성하는게 좋을 것 같아서 일단 뺐습니다.
