### PR TITLE
[AUD-37] 마커 경로 그리기 기능 최적화

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,4 +1,4 @@
-import type { MarkersType } from "@/types/map";
+import type { MarkerType } from "@/types/map";
 
 // T-MAP API NameSpace
 declare global {
@@ -9,8 +9,8 @@ declare global {
     }
 
     interface CustomEventMap {
-        createMarker: CustomEvent<MarkersType>;
-        removeMarker: CustomEvent<number>;
+        'marker:create': CustomEvent<MarkerType>;
+        'marker:remove': CustomEvent<number>;
     }
 
     interface WindowEventMap extends CustomEventMap {}

--- a/global.d.ts
+++ b/global.d.ts
@@ -9,7 +9,8 @@ declare global {
     }
 
     interface CustomEventMap {
-        modifyMarkers: CustomEvent<MarkersType[]>;
+        createMarker: CustomEvent<MarkersType>;
+        removeMarker: CustomEvent<number>;
     }
 
     interface WindowEventMap extends CustomEventMap {}

--- a/src/features/course/course-item/CourseItem.tsx
+++ b/src/features/course/course-item/CourseItem.tsx
@@ -13,14 +13,14 @@ import {
     CourseViewContextValue,
 } from '@/features/course/course-view/CourseViewContextProvider';
 import { useOnClickOutside } from '@/hooks/useOnClickOutside';
-import { MarkersType } from '@/types/map';
+import { MarkerType } from '@/types/map';
 
 import CourseCheckBox from './CourseCheckBox';
 import CourseControlBox from './CourseControlBox';
 import * as S from './CourseItem.css';
 
 interface PropsType {
-    marker: MarkersType;
+    marker: MarkerType;
     order: number;
 }
 

--- a/src/features/course/course-view/CourseView.tsx
+++ b/src/features/course/course-view/CourseView.tsx
@@ -6,7 +6,7 @@ import CourseItem from '@/features/course/course-item';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useEventListeners } from '@/hooks/useEventListeners';
 import { useTmap } from '@/hooks/useTmap';
-import type { MarkersType } from '@/types/map';
+import type { MarkerType } from '@/types/map';
 
 import * as S from './CourseView.css';
 import CourseViewContextProvider from './CourseViewContextProvider';
@@ -14,25 +14,25 @@ import CourseViewContextProvider from './CourseViewContextProvider';
 const REORDER_DELAY = 330;
 
 const CourseView = () => {
-    const [markers, setMarkers] = useState<MarkersType[]>([]);
+    const [markers, setMarkers] = useState<MarkerType[]>([]);
     const { tmapModuleRef } = useTmap();
 
     const { debounce } = useDebounce();
 
-    useEventListeners('createMarker', (event) => {
+    useEventListeners('marker:create', (event) => {
         setMarkers((previous) => [...previous, event.detail]);
     });
 
-    useEventListeners('removeMarker', (event) => {
+    useEventListeners('marker:remove', (event) => {
         setMarkers(markers.filter((_, index) => index !== event.detail));
     });
 
-    const debouncedModifyMarker = debounce((newOrder: MarkersType[]) => {
+    const debouncedModifyMarker = debounce((newOrder: MarkerType[]) => {
         if (!tmapModuleRef.current) return;
         tmapModuleRef.current.modifyMarker(newOrder);
     }, REORDER_DELAY);
 
-    const handleReorderMarker = (newOrder: MarkersType[]) => {
+    const handleReorderMarker = (newOrder: MarkerType[]) => {
         setMarkers(newOrder);
         debouncedModifyMarker(newOrder);
     };

--- a/src/features/course/course-view/CourseView.tsx
+++ b/src/features/course/course-view/CourseView.tsx
@@ -11,7 +11,7 @@ import type { MarkersType } from '@/types/map';
 import * as S from './CourseView.css';
 import CourseViewContextProvider from './CourseViewContextProvider';
 
-const REORDER_DELAY = 660;
+const REORDER_DELAY = 330;
 
 const CourseView = () => {
     const [markers, setMarkers] = useState<MarkersType[]>([]);

--- a/src/features/course/course-view/CourseView.tsx
+++ b/src/features/course/course-view/CourseView.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { Reorder } from 'framer-motion';
 
 import CourseItem from '@/features/course/course-item';
+import { useDebounce } from '@/hooks/useDebounce';
 import { useEventListeners } from '@/hooks/useEventListeners';
 import { useTmap } from '@/hooks/useTmap';
 import type { MarkersType } from '@/types/map';
@@ -10,18 +11,30 @@ import type { MarkersType } from '@/types/map';
 import * as S from './CourseView.css';
 import CourseViewContextProvider from './CourseViewContextProvider';
 
+const REORDER_DELAY = 660;
+
 const CourseView = () => {
     const [markers, setMarkers] = useState<MarkersType[]>([]);
     const { tmapModuleRef } = useTmap();
 
-    useEventListeners('modifyMarkers', (event) => {
-        setMarkers([...event.detail]);
+    const { debounce } = useDebounce();
+
+    useEventListeners('createMarker', (event) => {
+        setMarkers((previous) => [...previous, event.detail]);
     });
 
-    const handleReorderMarker = (newOrder: MarkersType[]) => {
+    useEventListeners('removeMarker', (event) => {
+        setMarkers(markers.filter((_, index) => index !== event.detail));
+    });
+
+    const debouncedModifyMarker = debounce((newOrder: MarkersType[]) => {
         if (!tmapModuleRef.current) return;
         tmapModuleRef.current.modifyMarker(newOrder);
+    }, REORDER_DELAY);
+
+    const handleReorderMarker = (newOrder: MarkersType[]) => {
         setMarkers(newOrder);
+        debouncedModifyMarker(newOrder);
     };
 
     return (

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -9,10 +9,12 @@ export const useDebounce = () => {
 
     const debounce = useCallback(
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        <T extends (...args: any[]) => void>(callback: T, delay: number) =>
+        <T extends (...args: any[]) => any>(callback: T, delay: number) =>
             (...args: Parameters<T>) => {
                 clearTimeout(timer.current);
-                timer.current = setTimeout(() => callback(...args), delay);
+                timer.current = setTimeout(() => {
+                    callback(...args)
+                }, delay);
             },
         [],
     );

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,0 +1,21 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * 일정 주기 동안 같은 함수가 Trigger 되지 않도록 debounce 처리된 함수를 반환하는 useDebounce
+ * delay 내로 debounce 함수가 다시 호출될 경우, timeout 이 초기화되어 delay 만큼 기다려야 함.
+ */
+export const useDebounce = () => {
+    const timer = useRef<NodeJS.Timeout>();
+
+    const debounce = useCallback(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        <T extends (...args: any[]) => void>(callback: T, delay: number) =>
+            (...args: Parameters<T>) => {
+                clearTimeout(timer.current);
+                timer.current = setTimeout(() => callback(...args), delay);
+            },
+        [],
+    );
+
+    return { debounce };
+};

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -1,7 +1,7 @@
 /** 지도에서 나타내는 경로의 타입 (보행자 | 자동차) */
 export type RouteModeType = 'Pedestrian' | 'Vehicle';
 
-export interface MarkersType {
+export interface MarkerType {
     marker: typeof window.Tmapv3.Marker;
     name: string;
     originName: string;

--- a/src/utils/tmap/tmapModule.tsx
+++ b/src/utils/tmap/tmapModule.tsx
@@ -106,7 +106,7 @@ export class TMapModule {
     }) {
         if (this.#markers.length >= this.#maxMarkerCount) return;
 
-        const createdMarker: MarkerType = {
+        const newMarker: MarkerType = {
             marker: new Tmapv3.Marker({
                 position: new Tmapv3.LatLng(lat, lng),
                 iconHTML,
@@ -130,13 +130,13 @@ export class TMapModule {
             });
         };
 
-        createdMarker.marker.on('Click', handleMarkerClick);
+        newMarker.marker.on('Click', handleMarkerClick);
 
-        this.#markers.push(createdMarker);
+        this.#markers.push(newMarker);
 
         window.dispatchEvent(
             new CustomEvent('marker:create', {
-                detail: createdMarker,
+                detail: newMarker,
             }),
         );
     }

--- a/src/utils/tmap/tmapModule.tsx
+++ b/src/utils/tmap/tmapModule.tsx
@@ -135,7 +135,15 @@ export class TMapModule {
         });
 
         window.dispatchEvent(
-            new CustomEvent('modifyMarkers', { detail: this.#markers }),
+            new CustomEvent('createMarker', { detail: {
+            marker,
+            name,
+            originName,
+            address,
+            id,
+            lat,
+            lng,
+        } }),
         );
     }
 
@@ -145,14 +153,13 @@ export class TMapModule {
         targetMarker.setMap(null);
 
         window.dispatchEvent(
-            new CustomEvent('modifyMarkers', { detail: this.#markers }),
+            new CustomEvent('removeMarker', { detail: markerIndex }),
         );
     }
 
     // 마커 수정
     modifyMarker(modifiedMarkers: MarkersType[]) {
-        // 기존의 경로와 핀을 모두 삭제한 후, 새로운 마커 목록을 기반으로 재구성
-        this.#removePath();
+        // 기존의 핀을 모두 삭제한 후, 새로운 마커 목록을 기반으로 재구성
         this.#markers.forEach(({ marker }) => marker.setMap(null));
         this.#markers = modifiedMarkers.map(
             ({ marker, lat, lng, ...rest }, index) => {
@@ -171,6 +178,8 @@ export class TMapModule {
 
         const startIndex = 0;
         const endIndex = modifiedMarkers.length - 1;
+
+        // NOTE : 경로를 그리는 과정이 오래 걸리므로 기다리지 않고 함수가 끝나도록 처리
         this.drawPathBetweenMarkers({ startIndex, endIndex });
     }
 


### PR DESCRIPTION
### 📃 변경사항  
- N개의 Polyline 을 사용하여 경로를 그리던 방식을 1개의 Polyline 만 사용하도록 수정했습니다.
- `useDebounce` 훅을 제작하고, 이를 CourseView 내 Drag & Drop 시 경로를 불러오는 로직에 반영했습니다.
- 기존의 Marker 이벤트 명을 `marker:${action}` 형식의 네이밍으로 수정하여 주체와 행동을 분리하여 명시했습니다.
- `MarkersType` 타입 명에 대한 표현이 어색하여 단수형인 `MarkerType` 으로 수정했습니다.
- `drawPathBetweenMarkers` 메서드가 index 를 인자로 받지 않고, 모든 마커에 대한 경로를 그리도록 수정했습니다.

### 🫨 고민한 부분 (optional)  
Tmap 으로부터 경로를 받아 지도에 그리는 과정에서 아래와 같이 리소스를 많이 잡아먹는 문제가 발생했습니다.

![222](https://github.com/Nexters/audy-client/assets/74497253/95c09351-2824-4c40-a200-0d51f3ce51f8)

이로 인해 Drag & Drop 과정에서 상당한 딜레이가 발생했고, 경로를 토글하는 과정에서도 많은 프레임 드랍이 발생했습니다.
원인은 기존의 로직이 경로를 그리기 위해 다수의 Polyline 클래스 인스턴스를 생성했던 것이 문제였습니다...

기존 로직은 각 인스턴스를 순회하며 `setMap(null)` 메서드를 호출하는데, 해당 작업은 DOM 을 직접 조작하는데다 병렬적으로 실행할 수도 없어 Polyline 의 수량이 많아질수록 작업에 걸리는 시간이 더욱 길어지는 결과를 초래했습니다.

따라서 이러한 문제를 아래 방식을 통해 해결했습니다.

1. Debounce 를 추가하여 Drag & Drop 발생 시 바로 API 를 호출하지 않고, 330 ms 의 딜레이를 걸어둠 (임시)
2. 다수의 Polyline 이 아닌 **단일 Polyline** 을 사용하여 경로를 한 개의 인스턴스로 제어하는 방식을 채택

![444](https://github.com/Nexters/audy-client/assets/74497253/6286cbf9-3f81-4718-8654-241dcf19c8b7)

다량의 경로 Instance 가 뭉친 Polyline 인 만큼 이에 대한 성능 저하 이슈가 있나 싶어 조사해봤으나 현재는 1,000 개 이상의 좌표를 담아도 잘 동작함을 확인했습니다.

- 기존 로직 : 경로 재구축 시 **평균 846ms**
- 수정 로직 : 경로 재구축 시 **평균 45ms**
