### PR TITLE
[AUD-46] 코스 API Repository 및 Query Hook 제작

### DIFF
--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -98,7 +98,7 @@ export async function putAsync<T, D>(
  * @param config Api 요청과 관련된 config (AxiosRequestConfig)
  * @returns API 요청 성공 시 받을 객체 (T)
  */
-export async function deleteAsync<T>(
+export async function deleteAsync<T, D>(
   url: string,
   config?: AxiosRequestConfig,
 ) {

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,6 +1,16 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 
 /**
+ * 백엔드로부터 인계 받은 응답의 기본 Interface ApiResponseType
+ * @param T 응답으로 받을 데이터의 타입
+ */
+interface ApiResponseType<T> {
+    code: number;
+    message: string;
+    data: T;
+}
+
+/**
  * API 요청에서 범용적으로 사용할 Axios Instance 생성
  * baseURL, responseType 같은 공용 속성을 일괄적으로 적용
  */
@@ -17,7 +27,11 @@ const API = axios.create({
  * @returns API 요청 성공 시 받을 객체 (T)
  */
 export async function getAsync<T>(url: string, config?: AxiosRequestConfig) {
-    const response = await API.get<T, AxiosResponse<T, unknown>, unknown>(url, {
+    const response = await API.get<
+        ApiResponseType<T>,
+        AxiosResponse<ApiResponseType<T>, unknown>,
+        unknown
+    >(url, {
         ...config,
     });
     return response.data;
@@ -38,7 +52,11 @@ export async function postAsync<T, D>(
     data: D,
     config?: AxiosRequestConfig,
 ) {
-    const response = await API.post<T, AxiosResponse<T, D>, D>(url, data, {
+    const response = await API.post<
+        ApiResponseType<T>,
+        AxiosResponse<ApiResponseType<T>, D>,
+        D
+    >(url, data, {
         ...config,
     });
     return response.data;
@@ -59,7 +77,11 @@ export async function patchAsync<T, D>(
     data: D,
     config?: AxiosRequestConfig,
 ) {
-    const response = await API.patch<T, AxiosResponse<T, D>, D>(url, data, {
+    const response = await API.patch<
+        ApiResponseType<T>,
+        AxiosResponse<ApiResponseType<T>, D>,
+        D
+    >(url, data, {
         ...config,
     });
     return response.data;
@@ -80,7 +102,11 @@ export async function putAsync<T, D>(
     data: D,
     config?: AxiosRequestConfig,
 ) {
-    const response = await API.patch<T, AxiosResponse<T, D>, D>(url, data, {
+    const response = await API.patch<
+        ApiResponseType<T>,
+        AxiosResponse<ApiResponseType<T>, D>,
+        D
+    >(url, data, {
         ...config,
     });
     return response.data;
@@ -100,12 +126,13 @@ export async function deleteAsync<T, D>(
     data?: D,
     config?: AxiosRequestConfig,
 ) {
-    const response = await API.delete<T, AxiosResponse<T, unknown>, unknown>(
-        url,
-        {
-            ...config,
-            data,
-        },
-    );
+    const response = await API.delete<
+        ApiResponseType<T>,
+        AxiosResponse<ApiResponseType<T>, unknown>,
+        unknown
+    >(url, {
+        ...config,
+        data,
+    });
     return response.data;
 }

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -5,7 +5,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
  * baseURL, responseType 같은 공용 속성을 일괄적으로 적용
  */
 const API = axios.create({
-  baseURL: import.meta.env.VITE_SERVER_URL,
+    baseURL: import.meta.env.VITE_SERVER_URL,
 });
 
 /**
@@ -16,14 +16,11 @@ const API = axios.create({
  * @param config API 요청과 관련된 config (AxiosRequestConfig)
  * @returns API 요청 성공 시 받을 객체 (T)
  */
-export async function getAsync<T>(
-  url: string,
-  config?: AxiosRequestConfig,
-) {
-  const response = await API.get<T, AxiosResponse<T, unknown>, unknown>(url, {
-    ...config,
-  });
-  return response.data;
+export async function getAsync<T>(url: string, config?: AxiosRequestConfig) {
+    const response = await API.get<T, AxiosResponse<T, unknown>, unknown>(url, {
+        ...config,
+    });
+    return response.data;
 }
 
 /**
@@ -37,14 +34,14 @@ export async function getAsync<T>(
  * @returnsAPI 요청 성공 시 받을 객체 (T)
  */
 export async function postAsync<T, D>(
-  url: string,
-  data: D,
-  config?: AxiosRequestConfig,
+    url: string,
+    data: D,
+    config?: AxiosRequestConfig,
 ) {
-  const response = await API.post<T, AxiosResponse<T, D>, D>(url, data, {
-    ...config,
-  });
-  return response.data;
+    const response = await API.post<T, AxiosResponse<T, D>, D>(url, data, {
+        ...config,
+    });
+    return response.data;
 }
 
 /**
@@ -58,14 +55,14 @@ export async function postAsync<T, D>(
  * @returns API 요청 성공 시 받을 객체 (T)
  */
 export async function patchAsync<T, D>(
-  url: string,
-  data: D,
-  config?: AxiosRequestConfig,
+    url: string,
+    data: D,
+    config?: AxiosRequestConfig,
 ) {
-  const response = await API.patch<T, AxiosResponse<T, D>, D>(url, data, {
-    ...config,
-  });
-  return response.data;
+    const response = await API.patch<T, AxiosResponse<T, D>, D>(url, data, {
+        ...config,
+    });
+    return response.data;
 }
 
 /**
@@ -82,12 +79,12 @@ export async function putAsync<T, D>(
     url: string,
     data: D,
     config?: AxiosRequestConfig,
-  ) {
+) {
     const response = await API.patch<T, AxiosResponse<T, D>, D>(url, data, {
-      ...config,
+        ...config,
     });
     return response.data;
-  }
+}
 
 /**
  * DELETE 요청을 처리하는 유틸 Api 함수 deleteAsync
@@ -99,11 +96,16 @@ export async function putAsync<T, D>(
  * @returns API 요청 성공 시 받을 객체 (T)
  */
 export async function deleteAsync<T, D>(
-  url: string,
-  config?: AxiosRequestConfig,
+    url: string,
+    data?: D,
+    config?: AxiosRequestConfig,
 ) {
-  const response = await API.delete<T, AxiosResponse<T, unknown>, unknown>(url, {
-    ...config,
-  });
-  return response.data;
+    const response = await API.delete<T, AxiosResponse<T, unknown>, unknown>(
+        url,
+        {
+            ...config,
+            data,
+        },
+    );
+    return response.data;
 }

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -4,7 +4,7 @@ import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
  * 백엔드로부터 인계 받은 응답의 기본 Interface ApiResponseType
  * @param T 응답으로 받을 데이터의 타입
  */
-interface ApiResponseType<T> {
+export interface ApiResponseType<T> {
     code: number;
     message: string;
     data: T;
@@ -27,11 +27,7 @@ const API = axios.create({
  * @returns API 요청 성공 시 받을 객체 (T)
  */
 export async function getAsync<T>(url: string, config?: AxiosRequestConfig) {
-    const response = await API.get<
-        ApiResponseType<T>,
-        AxiosResponse<ApiResponseType<T>, unknown>,
-        unknown
-    >(url, {
+    const response = await API.get<T, AxiosResponse<T, unknown>, unknown>(url, {
         ...config,
     });
     return response.data;
@@ -52,11 +48,7 @@ export async function postAsync<T, D>(
     data: D,
     config?: AxiosRequestConfig,
 ) {
-    const response = await API.post<
-        ApiResponseType<T>,
-        AxiosResponse<ApiResponseType<T>, D>,
-        D
-    >(url, data, {
+    const response = await API.post<T, AxiosResponse<T, D>, D>(url, data, {
         ...config,
     });
     return response.data;
@@ -77,13 +69,10 @@ export async function patchAsync<T, D>(
     data: D,
     config?: AxiosRequestConfig,
 ) {
-    const response = await API.patch<
-        ApiResponseType<T>,
-        AxiosResponse<ApiResponseType<T>, D>,
-        D
-    >(url, data, {
+    const response = await API.patch<T, AxiosResponse<T, D>, D>(url, data, {
         ...config,
     });
+
     return response.data;
 }
 
@@ -102,13 +91,10 @@ export async function putAsync<T, D>(
     data: D,
     config?: AxiosRequestConfig,
 ) {
-    const response = await API.patch<
-        ApiResponseType<T>,
-        AxiosResponse<ApiResponseType<T>, D>,
-        D
-    >(url, data, {
+    const response = await API.patch<T, AxiosResponse<T, D>, D>(url, data, {
         ...config,
     });
+
     return response.data;
 }
 
@@ -126,13 +112,13 @@ export async function deleteAsync<T, D>(
     data?: D,
     config?: AxiosRequestConfig,
 ) {
-    const response = await API.delete<
-        ApiResponseType<T>,
-        AxiosResponse<ApiResponseType<T>, unknown>,
-        unknown
-    >(url, {
-        ...config,
-        data,
-    });
+    const response = await API.delete<T, AxiosResponse<T, unknown>, unknown>(
+        url,
+        {
+            ...config,
+            data,
+        },
+    );
+
     return response.data;
 }

--- a/src/apis/course/index.ts
+++ b/src/apis/course/index.ts
@@ -1,12 +1,18 @@
-import { deleteAsync, getAsync, patchAsync, postAsync } from '@/apis/api';
+import {
+    ApiResponseType,
+    deleteAsync,
+    getAsync,
+    patchAsync,
+    postAsync,
+} from '@/apis/api';
 
 import type { CourseRequestParamType, CourseResponseType } from './type';
 
 export const CourseRepository = {
     async getCourse(courseId: number) {
-        const response = await getAsync<CourseResponseType['getCourse']>(
-            `/v1/courses/${courseId}`,
-        );
+        const response = await getAsync<
+            ApiResponseType<CourseResponseType['getCourse']>
+        >(`/v1/courses/${courseId}`);
         return response.data;
     },
 
@@ -14,15 +20,14 @@ export const CourseRepository = {
         page = 1,
         limit = 10,
     }: CourseRequestParamType['getAllCourses']) {
-        const response = await getAsync<CourseResponseType['getAllCourses']>(
-            `/v1/courses/all`,
-            {
-                params: {
-                    page,
-                    limit,
-                },
+        const response = await getAsync<
+            ApiResponseType<CourseResponseType['getAllCourses']>
+        >(`/v1/courses/all`, {
+            params: {
+                page,
+                limit,
             },
-        );
+        });
 
         return response.data;
     },
@@ -31,15 +36,14 @@ export const CourseRepository = {
         page = 1,
         limit = 10,
     }: CourseRequestParamType['getOwnedCourses']) {
-        const response = await getAsync<CourseResponseType['getOwnedCourses']>(
-            `/v1/courses/owner`,
-            {
-                params: {
-                    page,
-                    limit,
-                },
+        const response = await getAsync<
+            ApiResponseType<CourseResponseType['getOwnedCourses']>
+        >(`/v1/courses/owner`, {
+            params: {
+                page,
+                limit,
             },
-        );
+        });
 
         return response.data;
     },
@@ -48,15 +52,14 @@ export const CourseRepository = {
         page = 1,
         limit = 10,
     }: CourseRequestParamType['getOwnedCourses']) {
-        const response = await getAsync<CourseResponseType['getMemberCourses']>(
-            `/v1/courses/member`,
-            {
-                params: {
-                    page,
-                    limit,
-                },
+        const response = await getAsync<
+            ApiResponseType<CourseResponseType['getMemberCourses']>
+        >(`/v1/courses/member`, {
+            params: {
+                page,
+                limit,
             },
-        );
+        });
         return response.data;
     },
 
@@ -65,7 +68,7 @@ export const CourseRepository = {
         courseId,
     }: CourseRequestParamType['postInviteCourse']) {
         return postAsync<
-            CourseResponseType['postInviteCourse'],
+            ApiResponseType<CourseResponseType['postInviteCourse']>,
             CourseRequestParamType['postInviteCourse']
         >('/v1/courses/invite', {
             userId,
@@ -78,14 +81,14 @@ export const CourseRepository = {
         courseId,
         courseName,
     }: CourseRequestParamType['patchUpdateCourse']) {
-        return patchAsync<void, CourseRequestParamType['patchUpdateCourse']>(
-            '/v1/courses',
-            {
-                userId,
-                courseId,
-                courseName,
-            },
-        );
+        await patchAsync<
+            ApiResponseType<void>,
+            CourseRequestParamType['patchUpdateCourse']
+        >('/v1/courses', {
+            userId,
+            courseId,
+            courseName,
+        });
     },
 
     async postSaveCourse({
@@ -93,7 +96,7 @@ export const CourseRepository = {
         courseName,
     }: CourseRequestParamType['postSaveCourse']) {
         return postAsync<
-            CourseResponseType['postSaveCourse'],
+            ApiResponseType<CourseResponseType['postSaveCourse']>,
             CourseRequestParamType['postSaveCourse']
         >('/v1/courses/invite', {
             userId,
@@ -105,12 +108,12 @@ export const CourseRepository = {
         userId,
         courseId,
     }: CourseRequestParamType['deleteCourse']) {
-        return deleteAsync<void, CourseRequestParamType['deleteCourse']>(
-            '/v1/courses',
-            {
-                userId,
-                courseId,
-            },
-        );
+        await deleteAsync<
+            ApiResponseType<void>,
+            CourseRequestParamType['deleteCourse']
+        >('/v1/courses', {
+            userId,
+            courseId,
+        });
     },
 };

--- a/src/apis/course/index.ts
+++ b/src/apis/course/index.ts
@@ -4,16 +4,17 @@ import type { CourseRequestParamType, CourseResponseType } from './type';
 
 export const CourseRepository = {
     async getCourse(courseId: number) {
-        return getAsync<CourseResponseType['getCourse']>(
+        const response = await getAsync<CourseResponseType['getCourse']>(
             `/v1/courses/${courseId}`,
         );
+        return response.data;
     },
 
     async getAllCourses({
         page = 1,
         limit = 10,
     }: CourseRequestParamType['getAllCourses']) {
-        return getAsync<CourseResponseType['getAllCourses']>(
+        const response = await getAsync<CourseResponseType['getAllCourses']>(
             `/v1/courses/all`,
             {
                 params: {
@@ -22,13 +23,15 @@ export const CourseRepository = {
                 },
             },
         );
+
+        return response.data;
     },
 
     async getOwnedCourses({
         page = 1,
         limit = 10,
     }: CourseRequestParamType['getOwnedCourses']) {
-        return getAsync<CourseResponseType['getOwnedCourses']>(
+        const response = await getAsync<CourseResponseType['getOwnedCourses']>(
             `/v1/courses/owner`,
             {
                 params: {
@@ -37,13 +40,15 @@ export const CourseRepository = {
                 },
             },
         );
+
+        return response.data;
     },
 
     async getMemberCourses({
         page = 1,
         limit = 10,
     }: CourseRequestParamType['getOwnedCourses']) {
-        return getAsync<CourseResponseType['getMemberCourses']>(
+        const response = await getAsync<CourseResponseType['getMemberCourses']>(
             `/v1/courses/member`,
             {
                 params: {
@@ -52,6 +57,7 @@ export const CourseRepository = {
                 },
             },
         );
+        return response.data;
     },
 
     async postInviteCourse({
@@ -106,5 +112,5 @@ export const CourseRepository = {
                 courseId,
             },
         );
-    }
+    },
 };

--- a/src/apis/course/index.ts
+++ b/src/apis/course/index.ts
@@ -9,14 +9,14 @@ import {
 import type { CourseRequestParamType, CourseResponseType } from './type';
 
 export const CourseRepository = {
-    async getCourse(courseId: number) {
+    async getCourseAsync(courseId: number) {
         const response = await getAsync<
             ApiResponseType<CourseResponseType['getCourse']>
         >(`/v1/courses/${courseId}`);
         return response.data;
     },
 
-    async getAllCourses({
+    async getAllCoursesAsync({
         page = 1,
         limit = 10,
     }: CourseRequestParamType['getAllCourses']) {
@@ -32,7 +32,7 @@ export const CourseRepository = {
         return response.data;
     },
 
-    async getOwnedCourses({
+    async getOwnedCoursesAsync({
         page = 1,
         limit = 10,
     }: CourseRequestParamType['getOwnedCourses']) {
@@ -48,7 +48,7 @@ export const CourseRepository = {
         return response.data;
     },
 
-    async getMemberCourses({
+    async getMemberCoursesAsync({
         page = 1,
         limit = 10,
     }: CourseRequestParamType['getOwnedCourses']) {
@@ -63,7 +63,7 @@ export const CourseRepository = {
         return response.data;
     },
 
-    async postInviteCourse({
+    async postInviteCourseAsync({
         userId,
         courseId,
     }: CourseRequestParamType['postInviteCourse']) {
@@ -76,7 +76,7 @@ export const CourseRepository = {
         });
     },
 
-    async patchUpdateCourse({
+    async patchUpdateCourseAsync({
         userId,
         courseId,
         courseName,
@@ -91,7 +91,7 @@ export const CourseRepository = {
         });
     },
 
-    async postSaveCourse({
+    async postSaveCourseAsync({
         userId,
         courseName,
     }: CourseRequestParamType['postSaveCourse']) {
@@ -104,7 +104,7 @@ export const CourseRepository = {
         });
     },
 
-    async deleteCourse({
+    async deleteCourseAsync({
         userId,
         courseId,
     }: CourseRequestParamType['deleteCourse']) {

--- a/src/apis/course/index.ts
+++ b/src/apis/course/index.ts
@@ -1,0 +1,70 @@
+import { deleteAsync, getAsync, patchAsync, postAsync } from '@/apis/api';
+
+import type { CourseRequestParamType, CourseResponseType } from './type';
+
+export const CourseRepository = {
+    async getCourse(courseId: number) {
+        return getAsync<CourseResponseType['getCourse']>(
+            `/v1/courses/${courseId}`,
+        );
+    },
+
+    async getAllCourses(courseId: number) {
+        return getAsync<CourseResponseType['getAllCourses']>(
+            `/v1/courses/${courseId}`,
+        );
+    },
+
+    async getOwnedCourses() {
+        return getAsync<CourseResponseType['getOwnedCourses']>(
+            `/v1/courses/owner`,
+        );
+    },
+
+    async getMemberCourses() {
+        return getAsync<CourseResponseType['getMemberCourses']>(
+            `/v1/courses/member`,
+        );
+    },
+
+    async postInviteCourse({
+        userId,
+        courseId,
+    }: CourseRequestParamType['postInviteCourse']) {
+        return postAsync<
+            CourseResponseType['postInviteCourse'],
+            CourseRequestParamType['postInviteCourse']
+        >('/v1/courses/invite', {
+            userId,
+            courseId,
+        });
+    },
+
+    async patchUpdateCourse({
+        userId,
+        courseId,
+        courseName,
+    }: CourseRequestParamType['patchUpdateCourse']) {
+        return patchAsync<void, CourseRequestParamType['patchUpdateCourse']>(
+            '/v1/courses',
+            {
+                userId,
+                courseId,
+                courseName,
+            },
+        );
+    },
+
+    async postSaveCourse({
+        userId,
+        courseName,
+    }: CourseRequestParamType['postSaveCourse']) {
+        return postAsync<
+            CourseResponseType['postSaveCourse'],
+            CourseRequestParamType['postSaveCourse']
+        >('/v1/courses/invite', {
+            userId,
+            courseName,
+        });
+    },
+};

--- a/src/apis/course/index.ts
+++ b/src/apis/course/index.ts
@@ -94,4 +94,17 @@ export const CourseRepository = {
             courseName,
         });
     },
+
+    async deleteCourse({
+        userId,
+        courseId,
+    }: CourseRequestParamType['deleteCourse']) {
+        return deleteAsync<void, CourseRequestParamType['deleteCourse']>(
+            '/v1/courses',
+            {
+                userId,
+                courseId,
+            },
+        );
+    }
 };

--- a/src/apis/course/index.ts
+++ b/src/apis/course/index.ts
@@ -9,21 +9,48 @@ export const CourseRepository = {
         );
     },
 
-    async getAllCourses(courseId: number) {
+    async getAllCourses({
+        page = 1,
+        limit = 10,
+    }: CourseRequestParamType['getAllCourses']) {
         return getAsync<CourseResponseType['getAllCourses']>(
-            `/v1/courses/${courseId}`,
+            `/v1/courses/all`,
+            {
+                params: {
+                    page,
+                    limit,
+                },
+            },
         );
     },
 
-    async getOwnedCourses() {
+    async getOwnedCourses({
+        page = 1,
+        limit = 10,
+    }: CourseRequestParamType['getOwnedCourses']) {
         return getAsync<CourseResponseType['getOwnedCourses']>(
             `/v1/courses/owner`,
+            {
+                params: {
+                    page,
+                    limit,
+                },
+            },
         );
     },
 
-    async getMemberCourses() {
+    async getMemberCourses({
+        page = 1,
+        limit = 10,
+    }: CourseRequestParamType['getOwnedCourses']) {
         return getAsync<CourseResponseType['getMemberCourses']>(
             `/v1/courses/member`,
+            {
+                params: {
+                    page,
+                    limit,
+                },
+            },
         );
     },
 

--- a/src/apis/course/type.ts
+++ b/src/apis/course/type.ts
@@ -1,4 +1,9 @@
+import { PaginationType } from "@/types";
+
 export interface CourseRequestParamType {
+    getAllCourses: PaginationType;
+    getOwnedCourses: PaginationType;
+    getMemberCourses: PaginationType;
     postInviteCourse: {
         userId: number;
         courseId: number;

--- a/src/apis/course/type.ts
+++ b/src/apis/course/type.ts
@@ -1,4 +1,4 @@
-import type { PaginationType, CourseType, CourseDetailType } from "@/types";
+import type { CourseDetailType, CourseType, PaginationType } from '@/types';
 
 export interface CourseRequestParamType {
     getAllCourses: PaginationType;
@@ -7,25 +7,25 @@ export interface CourseRequestParamType {
     postInviteCourse: {
         userId: number;
         courseId: number;
-    },
+    };
     patchUpdateCourse: {
         userId: number;
         courseId: number;
         courseName: string;
-    },
+    };
     postSaveCourse: {
         userId: number;
         courseName: number;
-    }
+    };
     deleteCourse: {
         userId: number;
-        courseId: number; 
-    }
+        courseId: number;
+    };
 }
 
 export interface CourseResponseType {
     getCourse: CourseDetailType;
-    getAllCourses: {
+    getAllCourses:{
         courseGetResList: CourseType[];
         isLast: boolean;
     };
@@ -42,5 +42,5 @@ export interface CourseResponseType {
     };
     postSaveCourse: {
         courseId: number;
-    }
+    };
 }

--- a/src/apis/course/type.ts
+++ b/src/apis/course/type.ts
@@ -17,6 +17,10 @@ export interface CourseRequestParamType {
         userId: number;
         courseName: number;
     }
+    deleteCourse: {
+        userId: number;
+        courseId: number; 
+    }
 }
 
 export interface CourseResponseType {

--- a/src/apis/course/type.ts
+++ b/src/apis/course/type.ts
@@ -1,0 +1,64 @@
+export interface CourseRequestParamType {
+    postInviteCourse: {
+        userId: number;
+        courseId: number;
+    },
+    patchUpdateCourse: {
+        userId: number;
+        courseId: number;
+        courseName: string;
+    },
+    postSaveCourse: {
+        userId: number;
+        courseName: number;
+    }
+}
+
+export interface CourseResponseType {
+    getCourse: {
+        courseId: number;
+        courseName: string;
+        pinList: {
+            pinId: string;
+            pinName: string;
+            originName: string;
+            latitude: number;
+            longitude: number;
+            address: string;
+            sequence: number;
+        }[];
+    };
+    getAllCourses: {
+        courseGetResList: {
+            courseId: number;
+            courseName: string;
+            pinCnt: number;
+            editorCnt: number;
+            owner: boolean;
+        }[];
+    };
+    getOwnedCourses: {
+        courseGetResList: {
+            courseId: number;
+            courseName: string;
+            pinCnt: number;
+            editorCnt: number;
+            owner: true;
+        }[];
+    };
+    getMemberCourses: {
+        courseGetResList: {
+            courseId: number;
+            courseName: string;
+            pinCnt: number;
+            editorCnt: number;
+            owner: boolean;
+        }[];
+    };
+    postInviteCourse: {
+        url: string;
+    };
+    postSaveCourse: {
+        courseId: number;
+    }
+}

--- a/src/apis/course/type.ts
+++ b/src/apis/course/type.ts
@@ -1,4 +1,4 @@
-import { PaginationType } from "@/types";
+import type { PaginationType, CourseType, CourseDetailType } from "@/types";
 
 export interface CourseRequestParamType {
     getAllCourses: PaginationType;
@@ -24,45 +24,18 @@ export interface CourseRequestParamType {
 }
 
 export interface CourseResponseType {
-    getCourse: {
-        courseId: number;
-        courseName: string;
-        pinList: {
-            pinId: string;
-            pinName: string;
-            originName: string;
-            latitude: number;
-            longitude: number;
-            address: string;
-            sequence: number;
-        }[];
-    };
+    getCourse: CourseDetailType;
     getAllCourses: {
-        courseGetResList: {
-            courseId: number;
-            courseName: string;
-            pinCnt: number;
-            editorCnt: number;
-            owner: boolean;
-        }[];
+        courseGetResList: CourseType[];
+        isLast: boolean;
     };
     getOwnedCourses: {
-        courseGetResList: {
-            courseId: number;
-            courseName: string;
-            pinCnt: number;
-            editorCnt: number;
-            owner: true;
-        }[];
+        courseGetResList: CourseType[];
+        isLast: boolean;
     };
     getMemberCourses: {
-        courseGetResList: {
-            courseId: number;
-            courseName: string;
-            pinCnt: number;
-            editorCnt: number;
-            owner: boolean;
-        }[];
+        courseGetResList: CourseType[];
+        isLast: boolean;
     };
     postInviteCourse: {
         url: string;

--- a/src/apis/tmap/index.ts
+++ b/src/apis/tmap/index.ts
@@ -82,8 +82,8 @@ export const TmapRepository = {
         );
     },
 
-    // 위경도 좌표를 기반으로 건물 명과 실제 주소를 찾는 getAddressFromLatLng
-    async getAddressFromLatLng({
+    // 위경도 좌표를 기반으로 건물 명과 실제 주소를 찾는 getAddressFromLatLngAsync
+    async getAddressFromLatLngAsync({
         lat,
         lng,
     }: TmapRequestParamsType['getAddressFromLatLng']) {
@@ -106,8 +106,8 @@ export const TmapRepository = {
         return response.addressInfo;
     },
 
-    // 특정 키워드를 기반으로 POI 검색을 통해 나온 정보를 제공하는 getPoiSearch
-    async getPoiSearch({
+    // 특정 키워드를 기반으로 POI 검색을 통해 나온 정보를 제공하는 getPoiSearchAsync
+    async getPoiSearchAsync({
         keyword,
         radius = 0,
     }: TmapRequestParamsType['getPoiSearch']) {

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,14 +1,18 @@
-import { getAsync } from '@/apis/api';
+import { type ApiResponseType, getAsync } from '@/apis/api';
 
 import { type UserResponseType } from './type';
 
 export const UserRepository = {
     // 유저 ID, 프로필 URL, 닉네임, 이메일 정보를 반환하는 메서드 getInformationAsync
     async getInformationAsync(userId?: string) {
-        return getAsync<UserResponseType['getInformation']>('/v1/users', {
-            params: {
-                ...(userId && { userId }),
+        const response = await getAsync<ApiResponseType<UserResponseType['getInformation']>>(
+            '/v1/users',
+            {
+                params: {
+                    ...(userId && { userId }),
+                },
             },
-        });
+        );
+        return response.data;
     },
 };

--- a/src/apis/user/type.ts
+++ b/src/apis/user/type.ts
@@ -1,8 +1,5 @@
+import { UserType } from "@/types";
+
 export interface UserResponseType {
-    getInformation: {
-        userId: string;
-        email: string;
-        username: string;
-        imageUrl: string;
-    };
+    getInformation: UserType;
 }

--- a/src/features/search/search-bar/SearchBar.tsx
+++ b/src/features/search/search-bar/SearchBar.tsx
@@ -21,7 +21,7 @@ const SearchBar = ({
     const [searchInputValue, setSearchInputValue] = useState('');
 
     const handleSearch = async () => {
-        const response = await TmapRepository.getPoiSearch({
+        const response = await TmapRepository.getPoiSearchAsync({
             keyword: searchInputValue,
         });
 

--- a/src/query-hooks/course/key.ts
+++ b/src/query-hooks/course/key.ts
@@ -1,0 +1,7 @@
+export const COURSE_QUERY_KEY = {
+    base: ['course'],
+    detail: (courseId: number) => [...COURSE_QUERY_KEY.base, 'detail', courseId],
+    list: () => [...COURSE_QUERY_KEY.base, 'list'],
+    owned: () => [...COURSE_QUERY_KEY.base, 'owned'],
+    member: () => [...COURSE_QUERY_KEY.base, 'member'],
+};

--- a/src/query-hooks/course/mutation.ts
+++ b/src/query-hooks/course/mutation.ts
@@ -1,0 +1,45 @@
+import { type UseMutationOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { CourseRepository } from '@/apis/course';
+import type { CourseRequestParamType } from '@/apis/course/type';
+import type { AxiosError } from 'axios';
+import { COURSE_QUERY_KEY } from './key';
+
+// 특정 코스를 삭제하는 Hook useDeleteCourse
+export const useDeleteCourse = ({
+    userId,
+    courseId,
+    ...options
+}: CourseRequestParamType['deleteCourse'] & UseMutationOptions<unknown, AxiosError>) => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        ...options,
+        mutationFn: () => CourseRepository.deleteCourse({ userId, courseId }),
+        onSuccess: () => {
+            queryClient.removeQueries({
+                queryKey: COURSE_QUERY_KEY.detail(courseId),
+            });
+        },
+        throwOnError: true,
+    });
+};
+
+// 코스 정보를 수정하는 Hook usePatchCourse
+export const usePatchCourse = ({
+    userId,
+    courseId,
+    courseName,
+    ...options
+}: CourseRequestParamType['patchUpdateCourse'] & UseMutationOptions<unknown, AxiosError>) => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        ...options,
+        mutationFn: () => CourseRepository.patchUpdateCourse({ courseId, userId, courseName }),
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: COURSE_QUERY_KEY.detail(courseId),
+            });
+        },
+        throwOnError: true,
+    });
+};

--- a/src/query-hooks/course/query.ts
+++ b/src/query-hooks/course/query.ts
@@ -13,8 +13,8 @@ import type { CourseDetailType, CourseType } from '@/types';
 
 import { COURSE_QUERY_KEY } from './key';
 
-// 생성된 코스 목록을 조회하는 Hook useGetCourseList
-export const useGetCourseList = ({
+// 생성된 코스 목록을 조회하는 Hook useGetCourses
+export const useGetCourses = ({
     limit = 10,
     ...options
 }: {
@@ -35,7 +35,7 @@ export const useGetCourseList = ({
     >({
         ...options,
         queryFn: ({ pageParam }) =>
-            CourseRepository.getAllCourses({ page: pageParam, limit }),
+            CourseRepository.getAllCoursesAsync({ page: pageParam, limit }),
         queryKey: COURSE_QUERY_KEY.list(),
         select: ({ pages }) =>
             pages.reduce<CourseType[]>(
@@ -51,8 +51,8 @@ export const useGetCourseList = ({
     });
 };
 
-// 내가 소유한 코스 목록을 조회하는 Hook useGetOwnCourseList
-export const useGetOwnCourseList = ({
+// 내가 소유한 코스 목록을 조회하는 Hook useGetOwnCourses
+export const useGetOwnCourses = ({
     limit = 10,
     ...options
 }: {
@@ -73,7 +73,7 @@ export const useGetOwnCourseList = ({
     >({
         ...options,
         queryFn: ({ pageParam }) =>
-            CourseRepository.getOwnedCourses({ page: pageParam, limit }),
+            CourseRepository.getOwnedCoursesAsync({ page: pageParam, limit }),
         queryKey: COURSE_QUERY_KEY.list(),
         select: ({ pages }) =>
             pages.reduce<CourseType[]>(
@@ -89,8 +89,8 @@ export const useGetOwnCourseList = ({
     });
 };
 
-// 내가 소속된 코스 목록을 조회하는 Hook useGetMemberCourseList
-export const useGetMemberCourseList = ({
+// 내가 소속된 코스 목록을 조회하는 Hook useGetMemberCourses
+export const useGetMemberCourses = ({
     limit = 10,
     ...options
 }: {
@@ -111,7 +111,7 @@ export const useGetMemberCourseList = ({
     >({
         ...options,
         queryFn: ({ pageParam }) =>
-            CourseRepository.getMemberCourses({ page: pageParam, limit }),
+            CourseRepository.getMemberCoursesAsync({ page: pageParam, limit }),
         queryKey: COURSE_QUERY_KEY.list(),
         select: ({ pages }) =>
             pages.reduce<CourseType[]>(
@@ -136,7 +136,7 @@ export const useGetCourseDetail = ({
     options: UseSuspenseQueryOptions<CourseDetailType, AxiosError>;
 }) => {
     return useSuspenseQuery<CourseDetailType, AxiosError>({
-        queryFn: () => CourseRepository.getCourse(courseId),
+        queryFn: () => CourseRepository.getCourseAsync(courseId),
         queryKey: COURSE_QUERY_KEY.detail(courseId),
         ...options,
     });

--- a/src/query-hooks/course/query.ts
+++ b/src/query-hooks/course/query.ts
@@ -1,0 +1,143 @@
+import {
+    QueryKey,
+    type UseSuspenseInfiniteQueryOptions,
+    type UseSuspenseQueryOptions,
+    useSuspenseInfiniteQuery,
+    useSuspenseQuery,
+} from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+
+import { CourseRepository } from '@/apis/course';
+import type { CourseResponseType } from '@/apis/course/type';
+import type { CourseDetailType, CourseType } from '@/types';
+
+import { COURSE_QUERY_KEY } from './key';
+
+// 생성된 코스 목록을 조회하는 Hook useGetCourseList
+export const useGetCourseList = ({
+    limit = 10,
+    ...options
+}: {
+    limit?: number;
+    options: UseSuspenseInfiniteQueryOptions<
+        CourseResponseType['getAllCourses'],
+        AxiosError,
+        CourseType[],
+        CourseType[]
+    >;
+}) => {
+    return useSuspenseInfiniteQuery<
+        CourseResponseType['getAllCourses'],
+        AxiosError,
+        CourseType[],
+        QueryKey,
+        number
+    >({
+        ...options,
+        queryFn: ({ pageParam }) =>
+            CourseRepository.getAllCourses({ page: pageParam, limit }),
+        queryKey: COURSE_QUERY_KEY.list(),
+        select: ({ pages }) =>
+            pages.reduce<CourseType[]>(
+                (previous, { courseGetResList = [] }) => [
+                    ...previous,
+                    ...courseGetResList,
+                ],
+                [],
+            ),
+        initialPageParam: 1,
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.isLast ? undefined : allPages.length + 1,
+    });
+};
+
+// 내가 소유한 코스 목록을 조회하는 Hook useGetOwnCourseList
+export const useGetOwnCourseList = ({
+    limit = 10,
+    ...options
+}: {
+    limit?: number;
+    options: UseSuspenseInfiniteQueryOptions<
+        CourseResponseType['getOwnedCourses'],
+        AxiosError,
+        CourseType[],
+        CourseType[]
+    >;
+}) => {
+    return useSuspenseInfiniteQuery<
+        CourseResponseType['getOwnedCourses'],
+        AxiosError,
+        CourseType[],
+        QueryKey,
+        number
+    >({
+        ...options,
+        queryFn: ({ pageParam }) =>
+            CourseRepository.getOwnedCourses({ page: pageParam, limit }),
+        queryKey: COURSE_QUERY_KEY.list(),
+        select: ({ pages }) =>
+            pages.reduce<CourseType[]>(
+                (previous, { courseGetResList = [] }) => [
+                    ...previous,
+                    ...courseGetResList,
+                ],
+                [],
+            ),
+        initialPageParam: 1,
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.isLast ? undefined : allPages.length + 1,
+    });
+};
+
+// 내가 소속된 코스 목록을 조회하는 Hook useGetMemberCourseList
+export const useGetMemberCourseList = ({
+    limit = 10,
+    ...options
+}: {
+    limit?: number;
+    options: UseSuspenseInfiniteQueryOptions<
+        CourseResponseType['getMemberCourses'],
+        AxiosError,
+        CourseType[],
+        CourseType[]
+    >;
+}) => {
+    return useSuspenseInfiniteQuery<
+        CourseResponseType['getMemberCourses'],
+        AxiosError,
+        CourseType[],
+        QueryKey,
+        number
+    >({
+        ...options,
+        queryFn: ({ pageParam }) =>
+            CourseRepository.getMemberCourses({ page: pageParam, limit }),
+        queryKey: COURSE_QUERY_KEY.list(),
+        select: ({ pages }) =>
+            pages.reduce<CourseType[]>(
+                (previous, { courseGetResList = [] }) => [
+                    ...previous,
+                    ...courseGetResList,
+                ],
+                [],
+            ),
+        initialPageParam: 1,
+        getNextPageParam: (lastPage, allPages) =>
+            lastPage.isLast ? undefined : allPages.length + 1,
+    });
+};
+
+// 특정 Course Id 를 가진 코스의 세부 목록을 불러오는 hook useGetCourseDetail
+export const useGetCourseDetail = ({
+    courseId,
+    ...options
+}: {
+    courseId: number;
+    options: UseSuspenseQueryOptions<CourseDetailType, AxiosError>;
+}) => {
+    return useSuspenseQuery<CourseDetailType, AxiosError>({
+        queryFn: () => CourseRepository.getCourse(courseId),
+        queryKey: COURSE_QUERY_KEY.detail(courseId),
+        ...options,
+    });
+};

--- a/src/query-hooks/user/key.ts
+++ b/src/query-hooks/user/key.ts
@@ -1,7 +1,7 @@
-export const QUERY_KEY = {
+export const USER_QUERY_KEY = {
     base: ['user'],
     info: (userId?: string) =>
         userId
-            ? [...QUERY_KEY.base, 'info', userId]
-            : [...QUERY_KEY.base, 'info'],
+            ? [...USER_QUERY_KEY.base, 'info', userId]
+            : [...USER_QUERY_KEY.base, 'info'],
 };

--- a/src/query-hooks/user/query.ts
+++ b/src/query-hooks/user/query.ts
@@ -5,9 +5,9 @@ import {
 import type { AxiosError } from 'axios';
 
 import { UserRepository } from '@/apis/user';
-import { UserResponseType } from '@/apis/user/type';
+import { UserType } from '@/types';
 
-import { QUERY_KEY } from './key';
+import { USER_QUERY_KEY } from './key';
 
 export const useGetUserInformation = ({
     userId,
@@ -15,18 +15,18 @@ export const useGetUserInformation = ({
 }: {
     userId?: string;
     options: UseSuspenseQueryOptions<
-        UserResponseType['getInformation'],
+        UserType,
         AxiosError,
-        UserResponseType['getInformation']
+        UserType
     >;
 }) => {
     return useSuspenseQuery<
-        UserResponseType['getInformation'],
+        UserType,
         AxiosError,
-        UserResponseType['getInformation']
+        UserType
     >({
         ...options,
         queryFn: () => UserRepository.getInformationAsync(userId),
-        queryKey: QUERY_KEY.info(userId),
+        queryKey: USER_QUERY_KEY.info(userId),
     });
 };

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,0 +1,8 @@
+export type SocialPlatformType = 'apple' | 'kakao';
+
+export interface UserType {
+    userId: string;
+    email: string;
+    username: string;
+    imageUrl: string;
+}

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,3 +1,5 @@
+import type { PinType } from "./map";
+
 export interface CourseInformationType {
     id: string;
     name: string;
@@ -5,5 +7,19 @@ export interface CourseInformationType {
     pinCount: number;
     isMyCourse: boolean;
 } // TODO: 임시 (백엔드 논의 후 수정 필요)
+
+export interface CourseType {
+    courseId: number;
+    courseName: string;
+    pinCnt: number;
+    editorCnt: number;
+    owner: boolean;
+}
+
+export interface CourseDetailType {
+    courseId: number;
+    courseName: string;
+    pinList: PinType[];
+};
 
 export type CourseTabType = 'allCourse' | 'myCourse' | 'invitedCourse';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,4 @@
-export * from './login';
+export * from './auth';
 export * from './map';
 export * from './course';
 export * from './search';

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -2,3 +2,4 @@ export * from './login';
 export * from './map';
 export * from './course';
 export * from './search';
+export * from './util';

--- a/src/types/login.ts
+++ b/src/types/login.ts
@@ -1,1 +1,0 @@
-export type SocialPlatformType = 'apple' | 'kakao';

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -10,3 +10,13 @@ export interface MarkerType {
     lat: string;
     lng: string;
 }
+
+export interface PinType {
+    pinId: string;
+    pinName: string;
+    originName: string;
+    latitude: number;
+    longitude: number;
+    address: string;
+    sequence: number;
+}

--- a/src/types/util.ts
+++ b/src/types/util.ts
@@ -1,0 +1,4 @@
+export type PaginationType = {
+    page?: number;
+    limit?: number;
+}

--- a/src/utils/tmap/tmapModule.tsx
+++ b/src/utils/tmap/tmapModule.tsx
@@ -69,7 +69,7 @@ export class TMapModule {
 
             const { _lat: lat, _lng: lng } = event._data.lngLat;
             const { fullAddress, buildingName, roadAddressKey } =
-                await TmapRepository.getAddressFromLatLng({
+                await TmapRepository.getAddressFromLatLngAsync({
                     lat,
                     lng,
                 });


### PR DESCRIPTION
### 📃 변경사항  
- 코스 API Repository 추가
- 백엔드 단에서 설계한 기본 Response 타입에 맞춰 ApiResponseType 유틸 타입 생성 (code, message, data)
- 코스 API 를 기반으로 컴포넌트 단에서 쓰일 비즈니스 로직을 담은 Custom Query Hook 제작
- 코스에 쓰일 유틸 타입 `CourseType`, `CourseDetailType` 정의
- Infinity Scroll 기능을 위한 `useIntersectionObserver` 커스텀 훅 제작

### 🫨 고민한 부분 (optional)  

- 백엔드 단에서 `{ code, message, data }` 형식으로 데이터를 보내고 있어 이 중 data 만을 정확히 가져오기 위해 별도의 타입을 명시했습니다.
- 다만 해당 타입은 T Map API 에서는 쓰이지 않기 때문에 Repository 단에서 사용하도록 타입을 설계했는데 혹시 더 좋은 방법이 있으면 부탁드립니다.