### PR TITLE
[AUD-62] 검색으로 추가한 마커 에러 해결

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,4 +1,4 @@
-import type { MarkerType } from "@/types/map";
+import type { MarkerType } from '@/types/map';
 
 // T-MAP API NameSpace
 declare global {
@@ -10,7 +10,7 @@ declare global {
 
     interface CustomEventMap {
         'marker:create': CustomEvent<MarkerType>;
-        'marker:remove': CustomEvent<number>;
+        'marker:remove': CustomEvent<string>;
     }
 
     interface WindowEventMap extends CustomEventMap {}

--- a/src/features/path/path-view/PathView.tsx
+++ b/src/features/path/path-view/PathView.tsx
@@ -25,7 +25,7 @@ const PathView = () => {
     });
 
     useEventListeners('marker:remove', (event) => {
-        setMarkers(markers.filter((_, index) => index !== event.detail));
+        setMarkers(markers.filter((marker) => marker.id !== event.detail));
     });
 
     const debouncedModifyMarker = debounce((newOrder: MarkerType[]) => {

--- a/src/features/search/search-result-tab/SearchResultTab.tsx
+++ b/src/features/search/search-result-tab/SearchResultTab.tsx
@@ -59,7 +59,7 @@ const SearchResultTab = ({ name, address, lat, lng, id }: PropsType) => {
             <div>
                 <p className={S.name}>{name}</p>
                 <div className={S.addressContainer}>
-                    <LocationIcon />
+                    <LocationIcon fill={COLOR.Gray400} width={14} height={14} />
                     <p className={S.address}>{address}</p>
                 </div>
             </div>
@@ -70,7 +70,7 @@ const SearchResultTab = ({ name, address, lat, lng, id }: PropsType) => {
                 </button>
             ) : (
                 <button className={S.pinButton} onClick={handlePinButtonClick}>
-                    <AddIcon />
+                    <AddIcon fill={COLOR.Gray400} />
                 </button>
             )}
         </div>

--- a/src/features/search/search-result-tab/SearchResultTab.tsx
+++ b/src/features/search/search-result-tab/SearchResultTab.tsx
@@ -53,7 +53,9 @@ const SearchResultTab = ({ name, address, lat, lng, id }: PropsType) => {
     };
 
     const handleTabClick = () => {
-        tmapModule?.createInfoWindow({
+        if (!tmapModule) return;
+
+        tmapModule.createInfoWindow({
             lat,
             lng,
             name,
@@ -61,7 +63,8 @@ const SearchResultTab = ({ name, address, lat, lng, id }: PropsType) => {
             id,
             isPinned: false,
         });
-        tmapModule?.zoomIn({ lat, lng });
+
+        tmapModule.zoomIn({ lat, lng });
     };
 
     return (

--- a/src/features/search/search-result-tab/SearchResultTab.tsx
+++ b/src/features/search/search-result-tab/SearchResultTab.tsx
@@ -5,6 +5,7 @@ import clsx from 'clsx';
 import AddIcon from '@/assets/icons/add.svg?react';
 import CheckIcon from '@/assets/icons/check.svg?react';
 import LocationIcon from '@/assets/icons/location.svg?react';
+import { useEventListeners } from '@/hooks/useEventListeners';
 import { useTmap } from '@/hooks/useTmap';
 import { COLOR } from '@/styles/foundation';
 
@@ -25,6 +26,10 @@ const SearchResultTab = ({ name, address, lat, lng, id }: PropsType) => {
     const pinState = tmapModule?.checkIsAlreadyPinned(id);
 
     const [isPinned, setIsPinned] = useState(pinState);
+
+    useEventListeners('marker:remove', (event) => {
+        if (event.detail === id) setIsPinned(false);
+    });
 
     const handlePinButtonClick = (event: React.MouseEvent) => {
         if (!tmapModule) return;

--- a/src/features/search/search-result-tab/SearchResultTab.tsx
+++ b/src/features/search/search-result-tab/SearchResultTab.tsx
@@ -42,7 +42,17 @@ const SearchResultTab = ({ name, address, lat, lng, id }: PropsType) => {
         setIsPinned(true);
     };
 
-    const handleTabClick = () => tmapModule?.zoomIn({ lat, lng });
+    const handleTabClick = () => {
+        tmapModule?.createInfoWindow({
+            lat,
+            lng,
+            name,
+            address,
+            id,
+            isPinned: false,
+        });
+        tmapModule?.zoomIn({ lat, lng });
+    };
 
     return (
         <div className={S.layout} onClick={handleTabClick}>

--- a/src/features/search/search-result-tab/SearchResultTab.tsx
+++ b/src/features/search/search-result-tab/SearchResultTab.tsx
@@ -26,8 +26,10 @@ const SearchResultTab = ({ name, address, lat, lng, id }: PropsType) => {
 
     const [isPinned, setIsPinned] = useState(pinState);
 
-    const handlePinButtonClick = () => {
+    const handlePinButtonClick = (event: React.MouseEvent) => {
         if (!tmapModule) return;
+
+        event.stopPropagation();
 
         tmapModule.createMarker({
             name,
@@ -36,6 +38,15 @@ const SearchResultTab = ({ name, address, lat, lng, id }: PropsType) => {
             id,
             lat,
             lng,
+        });
+
+        tmapModule.createInfoWindow({
+            lat,
+            lng,
+            name,
+            address,
+            id,
+            isPinned: true,
         });
 
         tmapModule.drawPathBetweenMarkers();

--- a/src/features/search/search-result-tab/SearchResultTab.tsx
+++ b/src/features/search/search-result-tab/SearchResultTab.tsx
@@ -49,7 +49,6 @@ const SearchResultTab = ({ name, address, lat, lng, id }: PropsType) => {
             isPinned: true,
         });
 
-        tmapModule.drawPathBetweenMarkers();
         setIsPinned(true);
     };
 

--- a/src/features/search/search-result-tab/index.ts
+++ b/src/features/search/search-result-tab/index.ts
@@ -1,0 +1,3 @@
+import SearchResultTab from './SearchResultTab';
+
+export default SearchResultTab;

--- a/src/utils/tmap/tmapModule.tsx
+++ b/src/utils/tmap/tmapModule.tsx
@@ -33,6 +33,7 @@ export class TMapModule {
     #infoWindow: typeof Tmapv3.InfoWindow = null;
 
     #maxMarkerCount = 15;
+    #zoomLevel = 17;
 
     constructor({
         mapId = 'tmap',
@@ -308,7 +309,7 @@ export class TMapModule {
         this.#infoWindow = infoWindow;
 
         this.#mapInstance.setCenter(infoWindowLatLng);
-        this.#mapInstance.setZoom(17);
+        this.#mapInstance.setZoom(this.#zoomLevel);
 
         const handlePinButtonClick = () => {
             if (this.#markers.length >= this.#maxMarkerCount) return;
@@ -369,7 +370,7 @@ export class TMapModule {
     // 특정 위경도로 줌인
     zoomIn({ lat, lng }: { lat: string; lng: string }) {
         this.#mapInstance.setCenter(new Tmapv3.LatLng(lat, lng));
-        this.#mapInstance.setZoom(19);
+        this.#mapInstance.setZoom(this.#zoomLevel);
     }
 
     // 이미 존재하는 핀인지 확인

--- a/src/utils/tmap/tmapModule.tsx
+++ b/src/utils/tmap/tmapModule.tsx
@@ -142,6 +142,8 @@ export class TMapModule {
                 detail: newMarker,
             }),
         );
+
+        this.drawPathBetweenMarkers();
     }
 
     // 마커 삭제
@@ -323,8 +325,6 @@ export class TMapModule {
                 lng,
             });
 
-            this.removeInfoWindow();
-
             this.createInfoWindow({
                 lat,
                 lng,
@@ -333,8 +333,6 @@ export class TMapModule {
                 id,
                 isPinned: true,
             });
-
-            if (this.#markers.length > 1) this.drawPathBetweenMarkers();
         };
 
         const handleUnPinButtonClick = () => {

--- a/src/utils/tmap/tmapModule.tsx
+++ b/src/utils/tmap/tmapModule.tsx
@@ -147,13 +147,15 @@ export class TMapModule {
     }
 
     // 마커 삭제
-    removeMarker(markerIndex: number) {
+    removeMarker(id: string) {
+        const markerIndex = this.#markers.findIndex(
+            (marker) => marker.id === id,
+        );
+
         const [{ marker: targetMarker }] = this.#markers.splice(markerIndex, 1);
         targetMarker.setMap(null);
 
-        window.dispatchEvent(
-            new CustomEvent('removeMarker', { detail: markerIndex }),
-        );
+        window.dispatchEvent(new CustomEvent('marker:remove', { detail: id }));
     }
 
     // 마커 수정
@@ -336,11 +338,7 @@ export class TMapModule {
         };
 
         const handleUnPinButtonClick = () => {
-            const markerIndex = this.#markers.findIndex(
-                (marker) => marker.id === id,
-            );
-
-            this.removeMarker(markerIndex);
+            this.removeMarker(id);
             this.removeInfoWindow();
 
             this.modifyMarker(this.#markers);


### PR DESCRIPTION
### 📃 변경사항  
- Before: 검색 탭 클릭하면 해당 위경도로 줌인만 됨 -> After: 검색 탭 클릭하면 해당 위경도로 줌인되며 인포창이 생성됨
- Before: 검색 탭의 핀 추가 버튼을 클릭하면 마커만 생성됨 -> After: 검색 탭 클릭하면 마커와 함께 인포창도 생성됨
- 검색으로 추가한 마커의 에러 해결
  - 기존에는 검색으로 추가한 마커를 삭제해도, 검색의 탭에 바로 반영되지 않고 여전히 체크표시로 남아있었음
  - 검색으로 추가한 마커를 삭제하면 바로 검색 탭의 버튼이 체크에서 + 모양으로 바뀌도록 변경
- 마커 삭제 시 index가 아니라 id를 받도록 변경
- 검색 관련해서 자잘한 스타일 수정
- createMarker 메서드 내에 drawPathBetweenMarkers 메서드를 추가 
  -> 마커 생성 시 drawPathBetweenMarkers 메서드를 별도로 호출할 필요 없어짐

### 🫨 고민한 부분 
- 검색으로 추가한 마커를 삭제했을 때 어떻게 바로 검색탭에 반영되도록 할 수 있을지
  - 고민이 많았는데 광인님이 말씀해주신대로 CustomEvent를 이용해 처리했습니다.

### 🎇 동작 화면 
https://github.com/Nexters/audy-client/assets/80266418/81344ca5-4b5b-4be2-a4a1-ed125a594d3f


### 💫 기타사항 
- 이번에는 어쩌다보니 여러 주제가 한 PR에 들어가게 되었네요.., 다음부터 잘 분리하도록 하겠습니다