### PR TITLE
[AUD-73] 토스트 컴포넌트 기능 구현

### DIFF
--- a/src/components/toast/Toast.css.ts
+++ b/src/components/toast/Toast.css.ts
@@ -1,0 +1,25 @@
+import { keyframes, style } from '@vanilla-extract/css';
+
+import { COLOR } from '@/styles/foundation';
+import { sprinkles } from '@/styles/sprinkle.css';
+
+const fadeOutAnimation = keyframes({
+    from: { opacity: 1 },
+    to: { opacity: 0 },
+});
+
+export const layout = style([
+    sprinkles({ typography: 'SemiBold16' }),
+    {
+        position: 'absolute',
+        border: `1px solid ${COLOR.Gray200}`,
+        backgroundColor: COLOR.MonoWhite,
+        borderRadius: '18px',
+        padding: '20px',
+        color: COLOR.Gray800,
+        zIndex: 1000,
+
+        animation: `${fadeOutAnimation} 3s ease-in-out`,
+        animationDelay: '3s',
+    },
+]);

--- a/src/components/toast/Toast.css.ts
+++ b/src/components/toast/Toast.css.ts
@@ -9,7 +9,7 @@ const fadeOutAnimation = keyframes({
 });
 
 export const layout = style([
-    sprinkles({ typography: 'SemiBold16' }),
+    sprinkles({ typography: 'SemiBold16', zIndex: 'toast' }),
     {
         position: 'absolute',
         border: `1px solid ${COLOR.Gray200}`,
@@ -17,7 +17,6 @@ export const layout = style([
         borderRadius: '18px',
         padding: '20px',
         color: COLOR.Gray800,
-        zIndex: 1000,
 
         animation: `${fadeOutAnimation} 3s ease-in-out`,
         animationDelay: '3s',

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,5 +1,7 @@
 import { useToast } from '@/hooks/useToast';
 
+import AppPortal from '../app-portal';
+
 import * as S from './Toast.css';
 
 const Toast = () => {
@@ -8,9 +10,11 @@ const Toast = () => {
     if (!toastMessage) return null;
 
     return (
-        <div className={S.layout} onAnimationEnd={() => setToast('')}>
-            {toastMessage}
-        </div>
+        <AppPortal.Wrapper>
+            <div className={S.layout} onAnimationEnd={() => setToast('')}>
+                {toastMessage}
+            </div>
+        </AppPortal.Wrapper>
     );
 };
 

--- a/src/components/toast/Toast.tsx
+++ b/src/components/toast/Toast.tsx
@@ -1,0 +1,17 @@
+import { useToast } from '@/hooks/useToast';
+
+import * as S from './Toast.css';
+
+const Toast = () => {
+    const { toastMessage, setToast } = useToast();
+
+    if (!toastMessage) return null;
+
+    return (
+        <div className={S.layout} onAnimationEnd={() => setToast('')}>
+            {toastMessage}
+        </div>
+    );
+};
+
+export default Toast;

--- a/src/components/toast/index.ts
+++ b/src/components/toast/index.ts
@@ -1,0 +1,3 @@
+import Toast from './Toast';
+
+export default Toast;

--- a/src/hooks/useToast.ts
+++ b/src/hooks/useToast.ts
@@ -2,6 +2,11 @@ import { useContext } from 'react';
 
 import { ToastContext } from '@/utils/toast/ToastProvider';
 
+/**
+ * Toast를 사용할 수 있는 Hook useToast
+ * setToast에 토스트 메시지를 전달하여 토스트를 띄울 수 있음
+ */
+
 export const useToast = () => {
     const { toastMessage, setToastMessage } = useContext(ToastContext);
 

--- a/src/hooks/useToast.tsx
+++ b/src/hooks/useToast.tsx
@@ -1,0 +1,11 @@
+import { useContext } from 'react';
+
+import { ToastContext } from '@/utils/toast/ToastProvider';
+
+export const useToast = () => {
+    const { toastMessage, setToastMessage } = useContext(ToastContext);
+
+    const setToast = (message: string) => setToastMessage(message);
+
+    return { toastMessage, setToast };
+};

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -3,10 +3,12 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Outlet, createBrowserRouter } from 'react-router-dom';
 
 import AppPortal from '@/components/app-portal';
+import Toast from '@/components/toast';
 import { CoursePage, coursePageLoader } from '@/pages/course';
 import LoginPage from '@/pages/login';
 import MainPage from '@/pages/main';
 import { TmapProvider } from '@/utils/tmap/TmapModuleProvider';
+import { ToastProvider } from '@/utils/toast/ToastProvider';
 
 const queryClient = new QueryClient({
     defaultOptions: {
@@ -20,15 +22,19 @@ const queryClient = new QueryClient({
 const InitializedRouter = () => (
     <QueryClientProvider client={queryClient}>
         <AppPortal.Provider>
-            <TmapProvider
-                width="100%"
-                height="calc(100vh - 64px)"
-                lat={37.5652045}
-                lng={126.98702028}
-            >
-                <ReactQueryDevtools />
-                <Outlet />
-            </TmapProvider>
+            <ToastProvider>
+                <Toast />
+
+                <TmapProvider
+                    width="100%"
+                    height="calc(100vh - 64px)"
+                    lat={37.5652045}
+                    lng={126.98702028}
+                >
+                    <ReactQueryDevtools />
+                    <Outlet />
+                </TmapProvider>
+            </ToastProvider>
         </AppPortal.Provider>
     </QueryClientProvider>
 );

--- a/src/styles/foundation.ts
+++ b/src/styles/foundation.ts
@@ -3,6 +3,7 @@ export const Z_INDEX = {
     globalNavigation: 999,
     mapFloatMenu: 9,
     pathPopover: 10,
+    toast: 100,
 };
 
 export const FONT = {

--- a/src/utils/toast/ToastProvider.tsx
+++ b/src/utils/toast/ToastProvider.tsx
@@ -1,0 +1,23 @@
+import { PropsWithChildren, useState } from 'react';
+import { createContext } from 'react';
+
+interface ToastProviderType {
+    toastMessage: string;
+    setToastMessage: (message: string) => void;
+}
+
+export const ToastContext = createContext<ToastProviderType>(
+    {} as ToastProviderType,
+);
+
+interface PropsType extends PropsWithChildren {}
+
+export const ToastProvider = ({ children }: PropsType) => {
+    const [toastMessage, setToastMessage] = useState<string>('');
+
+    return (
+        <ToastContext.Provider value={{ toastMessage, setToastMessage }}>
+            {children}
+        </ToastContext.Provider>
+    );
+};

--- a/src/utils/toast/ToastProvider.tsx
+++ b/src/utils/toast/ToastProvider.tsx
@@ -10,9 +10,7 @@ export const ToastContext = createContext<ToastProviderType>(
     {} as ToastProviderType,
 );
 
-interface PropsType extends PropsWithChildren {}
-
-export const ToastProvider = ({ children }: PropsType) => {
+export const ToastProvider = ({ children }: PropsWithChildren) => {
     const [toastMessage, setToastMessage] = useState<string>('');
 
     return (


### PR DESCRIPTION
### 📃 변경사항  
- Toast 내용물을 저장하는 ToastProvider 생성
- Toast를 사용할 수 있는 useToast hook 구현
  - 아래와 같이 사용할 수 있음 
  ```ts
  const { setToast } = useToast();
  setToast( '토스트 냠뇸뇸^^' );
  ``` 
- Toast 공용 컴포넌트 생성


### 🫨 고민한 부분 
- Toast를 어떻게 구현할지
  - 어떤식으로 Toast와 useToast를 구현할지 고민을 꽤나 했습니다.
  - 전역을 최대한 안쓰는게 좋다고 생각했으나, 그럴 경우에는 Toast를 쓰는 곳마다 `<Toast />`를 호출할 수밖에 없다고 판단했습니다.
  - 사용상의 편의를 위해서 ToastProvider를 만들게 되었습니다.
  - 결과적으로는, 
    - Toast의 메시지를 전역으로 저장하고
    - Toast 메시지가 빈문자열이면 Toast 컴포넌트가 null을 반환하며
    - 빈문자열이 아닐 경우에는 3초 후 빈문자열이 되도록 했습니다.
    - 여기서 setTimeout을 쓰지 않고 onAnimationEnd를 사용하여 구현했습니다.


### 🎇 동작 화면 
https://github.com/Nexters/audy-client/assets/80266418/4cff9137-624a-47b0-a2af-09de12d6914c


### 💫 기타사항
- 디자인이 미완성된 관계로 기능만 따로 이슈 분리하였습니다.
- Toast 구현에 있어 더 좋은 방법이 있으면 코멘트 주세요! 
