### PR TITLE
[AUD-67] 코스 상세 정보 API 연동

### DIFF
--- a/src/apis/tmap/index.ts
+++ b/src/apis/tmap/index.ts
@@ -109,6 +109,8 @@ export const TmapRepository = {
     // 특정 키워드를 기반으로 POI 검색을 통해 나온 정보를 제공하는 getPoiSearchAsync
     async getPoiSearchAsync({
         keyword,
+        page = 1,
+        limit = 10,
         radius = 0,
     }: TmapRequestParamsType['getPoiSearch']) {
         const response = await getAsync<TmapResponseType['getPoiSearch']>(
@@ -124,8 +126,9 @@ export const TmapRepository = {
                     resCoordType: 'WGS84GEO',
                     reqCoordType: 'WGS84GEO',
                     radius,
-                    count: 10,
-                    searchType: 'all',
+                    page,
+                    count: limit,
+                    searchType: 'name',
                 },
             },
         );

--- a/src/apis/tmap/index.ts
+++ b/src/apis/tmap/index.ts
@@ -113,7 +113,7 @@ export const TmapRepository = {
         limit = 10,
         radius = 0,
     }: TmapRequestParamsType['getPoiSearch']) {
-        const response = await getAsync<TmapResponseType['getPoiSearch']>(
+        return await getAsync<TmapResponseType['getPoiSearch']>(
             '/pois',
             {
                 baseURL,
@@ -132,7 +132,5 @@ export const TmapRepository = {
                 },
             },
         );
-
-        return response.searchPoiInfo.pois.poi;
     },
 };

--- a/src/apis/tmap/type.ts
+++ b/src/apis/tmap/type.ts
@@ -27,6 +27,8 @@ export interface TmapRequestParamsType {
     };
     getPoiSearch: {
         keyword: string;
+        page?: number;
+        limit?: number;
         radius?: number;
     };
 }

--- a/src/apis/tmap/type.ts
+++ b/src/apis/tmap/type.ts
@@ -80,6 +80,9 @@ export interface TmapResponseType {
         };
     };
     getPoiSearch: {
+        totalCount: number;
+        count: number;
+        page: number;
         searchPoiInfo: {
             totalCount: number;
             count: number;

--- a/src/features/path/path-view/PathView.tsx
+++ b/src/features/path/path-view/PathView.tsx
@@ -33,17 +33,20 @@ const PathView = ({ pinList }: PropsType) => {
     });
 
     useEffect(() => {
-        pinList.forEach(({ pinName, pinId, address, latitude, longitude }) => {
-            if (!tmapModuleRef.current) return;
-            tmapModuleRef.current.createMarker({
-                name: pinName,
-                originName: pinName,
-                address,
-                id: pinId,
-                lat: String(latitude),
-                lng: String(longitude),
-            });
-        });
+        const createdMarkerList: MarkerType[] = pinList
+            .map(({ pinName, pinId, address, latitude, longitude }) => {
+                return tmapModuleRef.current?.createMarker({
+                    name: pinName,
+                    originName: pinName,
+                    address,
+                    id: pinId,
+                    lat: String(latitude),
+                    lng: String(longitude),
+                });
+            })
+            .filter((marker): marker is MarkerType => !!marker);
+
+        setMarkers(createdMarkerList);
     }, [pinList, tmapModuleRef]);
 
     const debouncedModifyMarker = debounce((newOrder: MarkerType[]) => {

--- a/src/features/path/path-view/PathView.tsx
+++ b/src/features/path/path-view/PathView.tsx
@@ -1,11 +1,11 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { Reorder } from 'framer-motion';
 
 import { useDebounce } from '@/hooks/useDebounce';
 import { useEventListeners } from '@/hooks/useEventListeners';
 import { useTmap } from '@/hooks/useTmap';
-import type { PinType, MarkerType } from '@/types/map';
+import type { MarkerType, PinType } from '@/types/map';
 
 import PathItem from '../path-item';
 
@@ -19,7 +19,7 @@ interface PropsType {
 }
 
 const PathView = ({ pinList }: PropsType) => {
-    const [markers, setMarkers] = useState<PinType[]>(pinList);
+    const [markers, setMarkers] = useState<MarkerType[]>([]);
     const { tmapModuleRef } = useTmap();
 
     const { debounce } = useDebounce();
@@ -32,7 +32,21 @@ const PathView = ({ pinList }: PropsType) => {
         setMarkers(markers.filter((marker) => marker.id !== event.detail));
     });
 
-    const debouncedModifyMarker = debounce((newOrder: PinType[]) => {
+    useEffect(() => {
+        pinList.forEach(({ pinName, pinId, address, latitude, longitude }) => {
+            if (!tmapModuleRef.current) return;
+            tmapModuleRef.current.createMarker({
+                name: pinName,
+                originName: pinName,
+                address,
+                id: pinId,
+                lat: String(latitude),
+                lng: String(longitude),
+            });
+        });
+    }, [pinList, tmapModuleRef]);
+
+    const debouncedModifyMarker = debounce((newOrder: MarkerType[]) => {
         if (!tmapModuleRef.current) return;
         tmapModuleRef.current.modifyMarker(newOrder);
     }, REORDER_DELAY);

--- a/src/features/path/path-view/PathView.tsx
+++ b/src/features/path/path-view/PathView.tsx
@@ -5,7 +5,7 @@ import { Reorder } from 'framer-motion';
 import { useDebounce } from '@/hooks/useDebounce';
 import { useEventListeners } from '@/hooks/useEventListeners';
 import { useTmap } from '@/hooks/useTmap';
-import type { MarkerType } from '@/types/map';
+import type { PinType, MarkerType } from '@/types/map';
 
 import PathItem from '../path-item';
 
@@ -14,8 +14,12 @@ import PathViewContextProvider from './PathViewContextProvider';
 
 const REORDER_DELAY = 330;
 
-const PathView = () => {
-    const [markers, setMarkers] = useState<MarkerType[]>([]);
+interface PropsType {
+    pinList: PinType[];
+}
+
+const PathView = ({ pinList }: PropsType) => {
+    const [markers, setMarkers] = useState<PinType[]>(pinList);
     const { tmapModuleRef } = useTmap();
 
     const { debounce } = useDebounce();
@@ -28,7 +32,7 @@ const PathView = () => {
         setMarkers(markers.filter((marker) => marker.id !== event.detail));
     });
 
-    const debouncedModifyMarker = debounce((newOrder: MarkerType[]) => {
+    const debouncedModifyMarker = debounce((newOrder: PinType[]) => {
         if (!tmapModuleRef.current) return;
         tmapModuleRef.current.modifyMarker(newOrder);
     }, REORDER_DELAY);

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,22 +1,9 @@
-import { QueryClientProvider } from '@tanstack/react-query';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { createRoot } from 'react-dom/client';
 import { RouterProvider } from 'react-router-dom';
 
-import { queryClient, router } from '@/routes/index.tsx';
+import { router } from '@/routes/index.tsx';
 import '@/styles/global.css';
-import { TmapProvider } from '@/utils/tmap/TmapModuleProvider';
 
 createRoot(document.getElementById('root')!).render(
-    <QueryClientProvider client={queryClient}>
-        <TmapProvider
-            width="100%"
-            height="calc(100vh - 64px)"
-            lat={37.5652045}
-            lng={126.98702028}
-        >
-            <RouterProvider router={router} />,
-        </TmapProvider>
-        <ReactQueryDevtools />
-    </QueryClientProvider>,
+    <RouterProvider router={router} />,
 );

--- a/src/pages/course/CoursePage.loader.ts
+++ b/src/pages/course/CoursePage.loader.ts
@@ -1,0 +1,22 @@
+import type { QueryClient } from '@tanstack/react-query';
+import { LoaderFunctionArgs, redirect } from 'react-router-dom';
+
+import { CourseRepository } from '@/apis/course';
+import { COURSE_QUERY_KEY } from '@/query-hooks/course/key';
+
+export const coursePageLoader =
+    (queryClient: QueryClient) =>
+    async ({ params }: LoaderFunctionArgs) => {
+        const courseId = Number(params.courseId);
+
+        if (Number.isNaN(courseId)) redirect('/');
+
+        try {
+            return await queryClient.ensureQueryData({
+                queryKey: COURSE_QUERY_KEY.detail(courseId),
+                queryFn: () => CourseRepository.getCourseAsync(courseId),
+            });
+        } catch (error) {
+            console.log(error);
+        }
+    };

--- a/src/pages/course/CoursePage.tsx
+++ b/src/pages/course/CoursePage.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import clsx from 'clsx';
+import { useParams } from 'react-router-dom';
 
 import LeftArrowIcon from '@/assets/icons/leftArrow.svg?react';
 import ModifyFilledIcon from '@/assets/icons/modifyFilled.svg?react';
@@ -11,22 +12,29 @@ import PathView from '@/features/path/path-view';
 import SearchBar from '@/features/search/search-bar';
 import SearchResultsContainer from '@/features/search/search-results-container';
 import { useTmap } from '@/hooks/useTmap';
+import { useGetCourseDetail } from '@/query-hooks/course/query';
 import { SearchResultType } from '@/types/search';
 
 import * as S from './CoursePage.css';
 
 function CoursePage() {
     const { mapContainerRef } = useTmap();
+    const { courseId } = useParams();
+
+    const {
+        data: { courseName, pinList = [] },
+    } = useGetCourseDetail({ courseId: Number(courseId) });
 
     const [isSearchMode, setIsSearchMode] = useState(false);
     const [searchResults, setSearchResults] = useState<SearchResultType[]>([]);
 
     const [isCourseNameEditing, setIsCourseNameEditing] = useState(false);
-    const [courseName, setCourseName] = useState('테스트 코스');
+    const [editedCourseName, setEditedCourseName] = useState(courseName);
 
     const handleCourseNameChange = ({
         target,
-    }: React.ChangeEvent<HTMLInputElement>) => setCourseName(target.value);
+    }: React.ChangeEvent<HTMLInputElement>) =>
+        setEditedCourseName(target.value);
 
     const handleCourseNameSave = () => {
         setIsCourseNameEditing(false);
@@ -53,7 +61,7 @@ function CoursePage() {
                                     type="text"
                                     className={S.courseNameInput}
                                     autoFocus
-                                    value={courseName}
+                                    value={editedCourseName}
                                     onChange={handleCourseNameChange}
                                 />
                                 <button
@@ -65,7 +73,9 @@ function CoursePage() {
                             </>
                         ) : (
                             <>
-                                <p className={S.courseName}>{courseName}</p>
+                                <p className={S.courseName}>
+                                    {editedCourseName}
+                                </p>
                                 <button
                                     className={S.courseNameEditButton}
                                     onClick={() => setIsCourseNameEditing(true)}
@@ -88,7 +98,7 @@ function CoursePage() {
                             isSearchMode && S.hidden,
                         )}
                     >
-                        <PathView />
+                        <PathView pinList={pinList} />
                     </div>
 
                     {isSearchMode && (

--- a/src/pages/course/index.ts
+++ b/src/pages/course/index.ts
@@ -1,3 +1,4 @@
 import CoursePage from './CoursePage';
+import { coursePageLoader } from './CoursePage.loader';
 
-export default CoursePage;
+export { CoursePage, coursePageLoader };

--- a/src/query-hooks/course/query.ts
+++ b/src/query-hooks/course/query.ts
@@ -17,14 +17,8 @@ import { COURSE_QUERY_KEY } from './key';
 export const useGetCourses = ({
     limit = 10,
     ...options
-<<<<<<< HEAD
 }: Omit<
     UseInfiniteQueryOptions<
-=======
-}: {
-    limit?: number;
-    options?: UseSuspenseInfiniteQueryOptions<
->>>>>>> 5a1fe3d (✨ option 타입을 optional 하게 받도록 수정)
         CourseResponseType['getAllCourses'],
         AxiosError,
         CourseType[],
@@ -64,14 +58,8 @@ export const useGetCourses = ({
 export const useGetOwnCourses = ({
     limit = 10,
     ...options
-<<<<<<< HEAD
 }: Omit<
     UseInfiniteQueryOptions<
-=======
-}: {
-    limit?: number;
-    options?: UseSuspenseInfiniteQueryOptions<
->>>>>>> 5a1fe3d (✨ option 타입을 optional 하게 받도록 수정)
         CourseResponseType['getOwnedCourses'],
         AxiosError,
         CourseType[],
@@ -111,14 +99,8 @@ export const useGetOwnCourses = ({
 export const useGetMemberCourses = ({
     limit = 10,
     ...options
-<<<<<<< HEAD
 }: Omit<
     UseInfiniteQueryOptions<
-=======
-}: {
-    limit?: number;
-    options?: UseSuspenseInfiniteQueryOptions<
->>>>>>> 5a1fe3d (✨ option 타입을 optional 하게 받도록 수정)
         CourseResponseType['getMemberCourses'],
         AxiosError,
         CourseType[],

--- a/src/query-hooks/course/query.ts
+++ b/src/query-hooks/course/query.ts
@@ -140,13 +140,20 @@ export const useGetMemberCourses = ({
 export const useGetCourseDetail = ({
     courseId,
     ...options
-}: {
+}: UseSuspenseQueryOptions<
+    CourseResponseType['getCourse'],
+    AxiosError,
+    CourseDetailType
+> & {
     courseId: number;
-    options?: UseSuspenseQueryOptions<CourseDetailType, AxiosError>;
 }) => {
-    return useSuspenseQuery<CourseDetailType, AxiosError>({
+    return useSuspenseQuery<
+        CourseResponseType['getCourse'],
+        AxiosError,
+        CourseDetailType
+    >({
+        ...options,
         queryFn: () => CourseRepository.getCourseAsync(courseId),
         queryKey: COURSE_QUERY_KEY.detail(courseId),
-        ...options,
     });
 };

--- a/src/query-hooks/course/query.ts
+++ b/src/query-hooks/course/query.ts
@@ -140,13 +140,19 @@ export const useGetMemberCourses = ({
 export const useGetCourseDetail = ({
     courseId,
     ...options
-}: UseSuspenseQueryOptions<
-    CourseResponseType['getCourse'],
-    AxiosError,
-    CourseDetailType
+}: Omit<
+    UseSuspenseQueryOptions<
+        CourseResponseType['getCourse'],
+        AxiosError,
+        CourseDetailType
+    >,
+    'queryKey'
 > & {
-    courseId: number;
+    courseId?: number;
 }) => {
+    if (!courseId)
+        throw new Error('courseId 는 number 타입의 값이어야 합니다.');
+
     return useSuspenseQuery<
         CourseResponseType['getCourse'],
         AxiosError,

--- a/src/query-hooks/course/query.ts
+++ b/src/query-hooks/course/query.ts
@@ -17,8 +17,14 @@ import { COURSE_QUERY_KEY } from './key';
 export const useGetCourses = ({
     limit = 10,
     ...options
+<<<<<<< HEAD
 }: Omit<
     UseInfiniteQueryOptions<
+=======
+}: {
+    limit?: number;
+    options?: UseSuspenseInfiniteQueryOptions<
+>>>>>>> 5a1fe3d (✨ option 타입을 optional 하게 받도록 수정)
         CourseResponseType['getAllCourses'],
         AxiosError,
         CourseType[],
@@ -58,8 +64,14 @@ export const useGetCourses = ({
 export const useGetOwnCourses = ({
     limit = 10,
     ...options
+<<<<<<< HEAD
 }: Omit<
     UseInfiniteQueryOptions<
+=======
+}: {
+    limit?: number;
+    options?: UseSuspenseInfiniteQueryOptions<
+>>>>>>> 5a1fe3d (✨ option 타입을 optional 하게 받도록 수정)
         CourseResponseType['getOwnedCourses'],
         AxiosError,
         CourseType[],
@@ -99,8 +111,14 @@ export const useGetOwnCourses = ({
 export const useGetMemberCourses = ({
     limit = 10,
     ...options
+<<<<<<< HEAD
 }: Omit<
     UseInfiniteQueryOptions<
+=======
+}: {
+    limit?: number;
+    options?: UseSuspenseInfiniteQueryOptions<
+>>>>>>> 5a1fe3d (✨ option 타입을 optional 하게 받도록 수정)
         CourseResponseType['getMemberCourses'],
         AxiosError,
         CourseType[],

--- a/src/query-hooks/search/key.ts
+++ b/src/query-hooks/search/key.ts
@@ -1,0 +1,4 @@
+export const SEARCH_QUERY_KEY = {
+    base: ['search'],
+    pois: (keyword: string) => [...SEARCH_QUERY_KEY.base, 'pois', keyword],
+};

--- a/src/query-hooks/search/query.ts
+++ b/src/query-hooks/search/query.ts
@@ -50,5 +50,6 @@ export const useGetSearchPois = ({
         getNextPageParam: ({ totalCount, page, count }) =>
             totalCount > page * count  ? undefined : page + 1,
         staleTime: 20 * 1000,
+        enabled: !!keyword,
     });
 };

--- a/src/query-hooks/search/query.ts
+++ b/src/query-hooks/search/query.ts
@@ -1,0 +1,54 @@
+import {
+    QueryKey,
+    type UseInfiniteQueryOptions,
+    useInfiniteQuery,
+} from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
+
+import { TmapRepository } from '@/apis/tmap';
+import type { TmapResponseType } from '@/apis/tmap/type';
+import type { SearchResultType } from '@/types';
+
+import { SEARCH_QUERY_KEY } from './key';
+
+// 생성된 코스 목록을 조회하는 Hook useGetCourses
+export const useGetSearchPois = ({
+    keyword,
+    limit = 10,
+    ...options
+}: Omit<
+    UseInfiniteQueryOptions<
+        TmapResponseType['getPoiSearch'],
+        AxiosError,
+        SearchResultType[],
+        TmapResponseType['getPoiSearch'],
+        QueryKey,
+        number
+    >,
+    'queryKey' | 'initialPageParam' | 'getNextPageParam'
+> & { keyword: string; limit?: number }) => {
+    return useInfiniteQuery<
+        TmapResponseType['getPoiSearch'],
+        AxiosError,
+        SearchResultType[],
+        QueryKey,
+        number
+    >({
+        ...options,
+        queryFn: ({ pageParam }) =>
+            TmapRepository.getPoiSearchAsync({ keyword, page: pageParam, limit }),
+        queryKey: SEARCH_QUERY_KEY.pois(keyword),
+        select: ({ pages }) =>
+            pages.reduce<SearchResultType[]>(
+                (previous, current) => [
+                    ...previous,
+                    ...current.searchPoiInfo.pois.poi,
+                ],
+                [],
+            ),
+        initialPageParam: 1,
+        getNextPageParam: ({ totalCount, page, count }) =>
+            totalCount > page * count  ? undefined : page + 1,
+        staleTime: 20 * 1000,
+    });
+};

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,11 +1,13 @@
-import { QueryClient } from '@tanstack/react-query';
-import { createBrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import { Outlet, createBrowserRouter } from 'react-router-dom';
 
-import CoursePage from '@/pages/course';
+import { CoursePage, coursePageLoader } from '@/pages/course';
 import LoginPage from '@/pages/login';
 import MainPage from '@/pages/main';
+import { TmapProvider } from '@/utils/tmap/TmapModuleProvider';
 
-export const queryClient = new QueryClient({
+const queryClient = new QueryClient({
     defaultOptions: {
         queries: {
             refetchOnWindowFocus: false,
@@ -14,19 +16,38 @@ export const queryClient = new QueryClient({
     },
 });
 
+const InitializedRouter = () => (
+    <QueryClientProvider client={queryClient}>
+        <TmapProvider
+            width="100%"
+            height="calc(100vh - 64px)"
+            lat={37.5652045}
+            lng={126.98702028}
+        >
+            <ReactQueryDevtools />
+            <Outlet />
+        </TmapProvider>
+    </QueryClientProvider>
+);
+
 export const router = createBrowserRouter([
     {
-        path: '/',
-        errorElement: <div>에러</div>,
-        element: <MainPage />,
-    },
-    {
-        path: 'login',
-        element: <LoginPage />,
-    },
-    {
-        // FIXME: 임시 라우팅
-        path: '/course',
-        element: <CoursePage />,
+        element: <InitializedRouter />,
+        children: [
+            {
+                path: '/',
+                errorElement: <div>에러</div>,
+                element: <MainPage />,
+            },
+            {
+                path: 'login',
+                element: <LoginPage />,
+            },
+            {
+                path: '/course/:courseId',
+                loader: coursePageLoader(queryClient),
+                element: <CoursePage />,
+            },
+        ],
     },
 ]);

--- a/src/utils/tmap/TmapModuleProvider.tsx
+++ b/src/utils/tmap/TmapModuleProvider.tsx
@@ -1,5 +1,7 @@
 import type { MutableRefObject, PropsWithChildren } from 'react';
-import { createContext, useEffect, useRef } from 'react';
+import { createContext, useLayoutEffect, useRef } from 'react';
+
+import { useInRouterContext } from 'react-router-dom';
 
 import { TMapModule, type TmapConstructorType } from './tmapModule';
 
@@ -28,10 +30,12 @@ export const TmapProvider = ({
 }: PropsType) => {
     const mapContainerRef = useRef<HTMLDivElement | null>(null);
     const tmapModuleRef = useRef<TMapModule | null>(null);
+    const isClientRendered = useInRouterContext();
 
-    useEffect(() => {
+    console.log(tmapModuleRef.current, 'tmapModuleRef');
+
+    useLayoutEffect(() => {
         if (!mapContainerRef.current) return;
-
         mapContainerRef.current.id = mapId;
 
         tmapModuleRef.current = new TMapModule({
@@ -42,7 +46,7 @@ export const TmapProvider = ({
             lat,
             lng,
         });
-    }, [height, lat, lng, mapId, width, zoom]);
+    }, [height, isClientRendered, lat, lng, mapId, width, zoom]);
 
     return (
         <TmapContext.Provider value={{ mapContainerRef, tmapModuleRef }}>

--- a/src/utils/tmap/TmapModuleProvider.tsx
+++ b/src/utils/tmap/TmapModuleProvider.tsx
@@ -1,5 +1,5 @@
 import type { MutableRefObject, PropsWithChildren } from 'react';
-import { createContext, useLayoutEffect, useRef } from 'react';
+import { createContext, useEffect, useRef } from 'react';
 
 import { useInRouterContext } from 'react-router-dom';
 
@@ -32,9 +32,7 @@ export const TmapProvider = ({
     const tmapModuleRef = useRef<TMapModule | null>(null);
     const isClientRendered = useInRouterContext();
 
-    console.log(tmapModuleRef.current, 'tmapModuleRef');
-
-    useLayoutEffect(() => {
+    useEffect(() => {
         if (!mapContainerRef.current) return;
         mapContainerRef.current.id = mapId;
 

--- a/src/utils/tmap/TmapModuleProvider.tsx
+++ b/src/utils/tmap/TmapModuleProvider.tsx
@@ -1,8 +1,6 @@
 import type { MutableRefObject, PropsWithChildren } from 'react';
 import { createContext, useEffect, useRef } from 'react';
 
-import { useInRouterContext } from 'react-router-dom';
-
 import { TMapModule, type TmapConstructorType } from './tmapModule';
 
 interface TmapProviderType {
@@ -30,7 +28,6 @@ export const TmapProvider = ({
 }: PropsType) => {
     const mapContainerRef = useRef<HTMLDivElement | null>(null);
     const tmapModuleRef = useRef<TMapModule | null>(null);
-    const isClientRendered = useInRouterContext();
 
     useEffect(() => {
         if (!mapContainerRef.current) return;
@@ -44,7 +41,7 @@ export const TmapProvider = ({
             lat,
             lng,
         });
-    }, [height, isClientRendered, lat, lng, mapId, width, zoom]);
+    }, [height, lat, lng, mapId, width, zoom]);
 
     return (
         <TmapContext.Provider value={{ mapContainerRef, tmapModuleRef }}>

--- a/src/utils/tmap/tmapModule.tsx
+++ b/src/utils/tmap/tmapModule.tsx
@@ -145,6 +145,8 @@ export class TMapModule {
         );
 
         this.drawPathBetweenMarkers();
+
+        return newMarker;
     }
 
     // 마커 삭제


### PR DESCRIPTION
### 📃 변경사항  
- 코스 ID 를 기반으로 코스 상세 정보를 서버로부터 받아 Page 에 전달하는 로직을 추가했습니다.
- CoursePageLoader 를 추가하여 렌더링 이전에 데이터를 미리 받아 Tanstack Query 에 세팅하는 작업을 추가했습니다.
- Loader 사용 시 `TmapModule` 이 타이밍 이슈로 동작하지 않던 문제를 Router 내부로 Provider 를 이전하여 해결했습니다.
- CoursePage 에 useGetCourseDetail 훅을 호출하고 해당 값을 기반으로 PathView 에 핀 목록을 내려주도록 유도했습니다.

### 🫨 고민한 부분
- createMarker 에서 생성된 마커를 반환받은 후 setState 를 호출하는 방식인데 조금 고민이 됩니다.
- 차라리 마커를 등록한 이후에 마커 목록을 한번에 받는 메서드를 호출해서 가져가는 게 맞지 않을까 싶네요. 

### 💫 기타사항 (optional)  
- 해당 태스크와는 연관이 없으나 검색 API 의 경우 페이지네이션 기반의 설계가 아니었던 점을 고려하여 구조를 수정했습니다.