### PR TITLE
[AUD-82] AppPortal 유틸 공용 컴포넌트 제작

### DIFF
--- a/src/components/app-portal/AppPortal.css.ts
+++ b/src/components/app-portal/AppPortal.css.ts
@@ -1,0 +1,12 @@
+import { style } from "@vanilla-extract/css";
+import { sprinkles } from "@/styles/sprinkle.css";
+
+export const Wrapper = style([
+    sprinkles({ zIndex: 'appPortal' }),
+    {
+    position: 'absolute',
+    left: 0,
+    top: 0,
+
+    width: '100%',
+}])

--- a/src/components/app-portal/AppPortal.tsx
+++ b/src/components/app-portal/AppPortal.tsx
@@ -1,0 +1,45 @@
+import {
+    type PropsWithChildren,
+    createContext,
+    useContext,
+    useState,
+} from 'react';
+
+import { createPortal } from 'react-dom';
+
+import * as S from './AppPortal.css';
+
+interface PropsType extends PropsWithChildren {
+    portalName?: string | undefined;
+}
+
+const PortalContext = createContext<HTMLDivElement | null>(null);
+
+const PortalProvider = ({ children }: PropsType) => {
+    const [portalContainer, setPortalContainer] =
+        useState<HTMLDivElement | null>(null);
+
+    return (
+        <PortalContext.Provider value={portalContainer}>
+            <div
+                className={S.Wrapper}
+                id="app-portal"
+                ref={(element) => {
+                    if (element && !portalContainer)
+                        setPortalContainer(element);
+                }}
+            />
+            {children}
+        </PortalContext.Provider>
+    );
+};
+
+const PortalWrapper = ({ children }: PropsType) => {
+    const portalContainer = useContext(PortalContext);
+    return portalContainer ? createPortal(children, portalContainer) : null;
+};
+
+export const AppPortal = {
+    Provider: PortalProvider,
+    Wrapper: PortalWrapper,
+};

--- a/src/components/app-portal/index.ts
+++ b/src/components/app-portal/index.ts
@@ -1,0 +1,3 @@
+import { AppPortal } from "./AppPortal";
+
+export default AppPortal;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -2,6 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { Outlet, createBrowserRouter } from 'react-router-dom';
 
+import AppPortal from '@/components/app-portal';
 import { CoursePage, coursePageLoader } from '@/pages/course';
 import LoginPage from '@/pages/login';
 import MainPage from '@/pages/main';
@@ -18,15 +19,17 @@ const queryClient = new QueryClient({
 
 const InitializedRouter = () => (
     <QueryClientProvider client={queryClient}>
-        <TmapProvider
-            width="100%"
-            height="calc(100vh - 64px)"
-            lat={37.5652045}
-            lng={126.98702028}
-        >
-            <ReactQueryDevtools />
-            <Outlet />
-        </TmapProvider>
+        <AppPortal.Provider>
+            <TmapProvider
+                width="100%"
+                height="calc(100vh - 64px)"
+                lat={37.5652045}
+                lng={126.98702028}
+            >
+                <ReactQueryDevtools />
+                <Outlet />
+            </TmapProvider>
+        </AppPortal.Provider>
     </QueryClientProvider>
 );
 

--- a/src/styles/foundation.ts
+++ b/src/styles/foundation.ts
@@ -1,4 +1,5 @@
 export const Z_INDEX = {
+    appPortal: 9999,
     globalNavigation: 999,
     mapFloatMenu: 9,
     pathPopover: 10,


### PR DESCRIPTION
### 📃 변경사항  
- 페이지 상단에 뜨는 Toast, SnackBar, Modal 과 같은 컴포넌트를 렌더링하는 별도의 Poral 을 제공하는 AppPortal 컴포넌트를 제작했습니다.
- 라우트 별 페이지 상단에 별도의 Element 를 생성하고, 이후 createPortal 을 사용하여 Wrapper 내부 children 컴포넌트를 렌더링 하도록 합니다.
- Provider, Wrapper 로 구현부를 분리하고 Wrapper 를 사용하여 Portal 내부에 렌더링할 요소를 children 으로 넣도록 설계했습니다.
<img width="537" alt="스크린샷 2024-02-24 오후 9 35 39" src="https://github.com/Nexters/audy-client/assets/74497253/01c31e50-a6a6-4d1f-a843-f82de5da91f8">

### 🫨 고민한 부분 (optional)  
- 하나의 Portal 에 여러 컴포넌트를 사용하도록 유도했으나 여러 개의 Portal 이 굳이 필요할까 싶었습니다.
- 하지만 Portal 내부에서 Index 를 별도로 제어하면 괜찮다고 판단하여 이러한 결정을 내리게 되었습니다. (관리 포인트 축소도 되고요)

### 💫 기타사항 (optional)  
- AppPortal 사용 방식은 아래와 같습니다.
```tsx
const Modal = () => (
    <AppPortal.Wrapper>
        <Modal.Wrapper>
                <p> 테스트 모달 </p>
        </Modal.Wrapper>
    </AppPortal.Wrapper>
)
```