### PR TITLE
[AUD-93] 에디터 프로필 컴포넌트 구현

### DIFF
--- a/src/components/global-navigation-bar/GlobalNavigationBar.css.ts
+++ b/src/components/global-navigation-bar/GlobalNavigationBar.css.ts
@@ -7,7 +7,8 @@ export const wrapper = style([
     sprinkles({ zIndex: 'globalNavigation' }),
     {
         width: '100%',
-        padding: '17px 30px',
+        height: '64px',
+        padding: '0 30px',
 
         display: 'flex',
         alignItems: 'center',
@@ -29,14 +30,15 @@ export const savingStatus = style([
 
 export const settingIcon = style({
     color: COLOR.Gray500,
+    margin: '0 0 0 26px',
 });
 
 export const settingContent = style({
     minWidth: '164px',
     transform: 'translate(0, calc(100% + 8px))',
-})
+});
 
-export const logoutText= style([
+export const logoutText = style([
     sprinkles({ typography: 'Regular15' }),
     {
         color: COLOR.Gray950,
@@ -48,4 +50,4 @@ export const withdrawText = style([
     {
         color: COLOR.Red500,
     },
-])
+]);

--- a/src/components/global-navigation-bar/GlobalNavigationBar.tsx
+++ b/src/components/global-navigation-bar/GlobalNavigationBar.tsx
@@ -1,27 +1,38 @@
+import { useLocation } from 'react-router-dom';
+
 import AudyLogoIcon from '@/assets/icons/audyLogo.svg?react';
 import SettingIcon from '@/assets/icons/setting.svg?react';
 import PopOver from '@/components/pop-over';
+import EditorList from '@/features/user/editor-list';
 
 import * as S from './GlobalNavigationBar.css';
 
-const GlobalNavigationBar = () => (
-    <div className={S.wrapper}>
-        <AudyLogoIcon />
-        <p className={S.savingStatus}>수정된 코스 저장중...</p>
-        <PopOver>
-            <PopOver.Trigger>
-                <SettingIcon className={S.settingIcon} />
-            </PopOver.Trigger>
-            <PopOver.Content className={S.settingContent}>
-                <PopOver.Item className={S.logoutText} >
-                    <p>로그아웃</p>
-                </PopOver.Item>
-                <PopOver.Item className={S.withdrawText}>
-                    <p>회원탈퇴</p>
-                </PopOver.Item>
-            </PopOver.Content>
-        </PopOver>
-    </div>
-);
+const GlobalNavigationBar = () => {
+    const { pathname } = useLocation();
+    const isCoursePage = pathname.split('/')[1] === 'course';
+
+    return (
+        <div className={S.wrapper}>
+            <AudyLogoIcon />
+            <p className={S.savingStatus}>수정된 코스 저장중...</p>
+
+            {isCoursePage && <EditorList />}
+
+            <PopOver>
+                <PopOver.Trigger>
+                    <SettingIcon className={S.settingIcon} />
+                </PopOver.Trigger>
+                <PopOver.Content className={S.settingContent}>
+                    <PopOver.Item className={S.logoutText}>
+                        <p>로그아웃</p>
+                    </PopOver.Item>
+                    <PopOver.Item className={S.withdrawText}>
+                        <p>회원탈퇴</p>
+                    </PopOver.Item>
+                </PopOver.Content>
+            </PopOver>
+        </div>
+    );
+};
 
 export default GlobalNavigationBar;

--- a/src/features/user/editor-list/EditorList.css.ts
+++ b/src/features/user/editor-list/EditorList.css.ts
@@ -1,0 +1,14 @@
+import { style } from '@vanilla-extract/css';
+
+import { COLOR } from '@/styles/foundation';
+
+export const layout = style({
+    display: 'flex',
+    gap: '4px',
+});
+
+export const editorInviteButton = style({
+    backgroundColor: COLOR.PinkPrimary,
+    borderRadius: '50%',
+    padding: '9px',
+});

--- a/src/features/user/editor-list/EditorList.tsx
+++ b/src/features/user/editor-list/EditorList.tsx
@@ -1,0 +1,53 @@
+import AddIcon from '@/assets/icons/add.svg?react';
+import { COLOR } from '@/styles/foundation';
+
+import EditorProfile from '../editor-profile';
+
+import * as S from './EditorList.css';
+
+const tempArr = [
+    // TODO: 서버에서 데이터 받아오는 방식으로 수정해야 함
+    {
+        profileImageUrl:
+            'https://i.pinimg.com/736x/a4/88/4a/a4884a65ac24c56d6446b08e4daed6f2.jpg',
+        isOnline: true,
+        editorName: '김가은',
+    },
+    {
+        profileImageUrl:
+            'https://mblogthumb-phinf.pstatic.net/MjAxODAzMTJfMjY4/MDAxNTIwNzk2NTI3ODAz.JMm0v9uPBYF0606VJJyQglt1swlEnMSrFkHu5jSXv28g.iSBfAUGxOl-UWxSa7BKOt0Aak_tTa-jnY2wCv9KeK4Ug.JPEG.x3x1121/27581124_1582122411908308_4737737849661554688_n.jpg?type=w800',
+        isOnline: false,
+        editorName: '백광인',
+    },
+    {
+        profileImageUrl:
+            'https://encrypted-tbn0.gstatic.com/images?q=tbn:ANd9GcSm-aOX9sTvS1y3t0IvP-vbvhNKnHpUQ-crSf3zJENQQ4qYu4_0xn_1jLODZdGyfpGdMEo&usqp=CAU',
+        isOnline: false,
+        editorName: '지코',
+    },
+];
+
+const EditorList = () => {
+    return (
+        <div className={S.layout}>
+            {tempArr.map(({ profileImageUrl, isOnline, editorName }, index) => {
+                return (
+                    <EditorProfile
+                        key={index}
+                        profileImageUrl={profileImageUrl}
+                        isOnline={isOnline}
+                        editorName={editorName}
+                    />
+                );
+            })}
+
+            {tempArr.length < 5 && (
+                <button className={S.editorInviteButton}>
+                    <AddIcon fill={COLOR.MonoWhite} width={20} height={20} />
+                </button>
+            )}
+        </div>
+    );
+};
+
+export default EditorList;

--- a/src/features/user/editor-list/index.ts
+++ b/src/features/user/editor-list/index.ts
@@ -1,0 +1,3 @@
+import EditorList from './EditorList';
+
+export default EditorList;

--- a/src/features/user/editor-profile/EditorProfile.css.ts
+++ b/src/features/user/editor-profile/EditorProfile.css.ts
@@ -23,6 +23,7 @@ export const profileImage = style({
     position: 'absolute',
     width: '38px',
     height: '38px',
+    objectFit: 'cover',
 });
 
 export const profileImageInnerBorder = style({

--- a/src/features/user/editor-profile/EditorProfile.css.ts
+++ b/src/features/user/editor-profile/EditorProfile.css.ts
@@ -1,0 +1,48 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { COLOR } from '@/styles/foundation';
+
+export const profileImageWrapper = style({
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: '50%',
+    overflow: 'hidden',
+    width: '38px',
+    height: '38px',
+});
+
+export const profileImage = style({
+    position: 'absolute',
+    width: '38px',
+    height: '38px',
+});
+
+export const profileImageInnerBorder = style({
+    position: 'absolute',
+    borderRadius: '50%',
+    width: '35px',
+    height: '35px',
+    border: `1.5px solid rgba(255, 255, 255, 0.9)`,
+});
+
+export const profileImageOuterBorder = recipe({
+    base: {
+        position: 'absolute',
+        borderRadius: '50%',
+        width: '38px',
+        height: '38px',
+    },
+    variants: {
+        isOnline: {
+            true: {
+                border: `2px solid ${COLOR.PinkPrimary}`,
+            },
+            false: {
+                border: `2px solid rgba(0, 0, 0, 0.1)`,
+            },
+        },
+    },
+});

--- a/src/features/user/editor-profile/EditorProfile.css.ts
+++ b/src/features/user/editor-profile/EditorProfile.css.ts
@@ -3,6 +3,11 @@ import { recipe } from '@vanilla-extract/recipes';
 
 import { COLOR } from '@/styles/foundation';
 
+export const layout = style({
+    position: 'relative',
+    width: 'max-content',
+});
+
 export const profileImageWrapper = style({
     position: 'relative',
     display: 'flex',
@@ -45,4 +50,12 @@ export const profileImageOuterBorder = recipe({
             },
         },
     },
+});
+
+export const tooltipWrapper = style({
+    display: 'flex',
+    justifyContent: 'center',
+    position: 'absolute',
+    top: 'calc(100% + 4px)',
+    left: '50%',
 });

--- a/src/features/user/editor-profile/EditorProfile.tsx
+++ b/src/features/user/editor-profile/EditorProfile.tsx
@@ -1,0 +1,29 @@
+import * as S from './EditorProfile.css';
+
+interface PropsType {
+    isOnline: boolean;
+    profileImageUrl?: string;
+    editorName: string;
+}
+
+const EditorProfile = ({
+    isOnline,
+    profileImageUrl,
+    editorName,
+}: PropsType) => {
+    const profileAlt = `${editorName}의 프로필 사진`;
+
+    return (
+        <div className={S.profileImageWrapper}>
+            <img
+                src={profileImageUrl}
+                alt={profileAlt}
+                className={S.profileImage}
+            />
+            <div className={S.profileImageInnerBorder} />
+            <div className={S.profileImageOuterBorder({ isOnline })} />
+        </div>
+    );
+};
+
+export default EditorProfile;

--- a/src/features/user/editor-profile/EditorProfile.tsx
+++ b/src/features/user/editor-profile/EditorProfile.tsx
@@ -1,3 +1,9 @@
+import { useState } from 'react';
+
+import { motion } from 'framer-motion';
+
+import Tooltip from '@/components/tooltip';
+
 import * as S from './EditorProfile.css';
 
 interface PropsType {
@@ -13,15 +19,33 @@ const EditorProfile = ({
 }: PropsType) => {
     const profileAlt = `${editorName}의 프로필 사진`;
 
+    const [isTooltipVisible, setIsTooltipVisible] = useState(false);
+
     return (
-        <div className={S.profileImageWrapper}>
-            <img
-                src={profileImageUrl}
-                alt={profileAlt}
-                className={S.profileImage}
-            />
-            <div className={S.profileImageInnerBorder} />
-            <div className={S.profileImageOuterBorder({ isOnline })} />
+        <div className={S.layout}>
+            <div
+                className={S.profileImageWrapper}
+                onMouseEnter={() => setIsTooltipVisible(true)}
+                onMouseLeave={() => setIsTooltipVisible(false)}
+            >
+                <img
+                    src={profileImageUrl}
+                    alt={profileAlt}
+                    className={S.profileImage}
+                />
+                <div className={S.profileImageInnerBorder} />
+                <div className={S.profileImageOuterBorder({ isOnline })} />
+            </div>
+
+            {isTooltipVisible && (
+                <motion.div
+                    className={S.tooltipWrapper}
+                    initial={{ scale: 0 }}
+                    animate={{ scale: 1 }}
+                >
+                    <Tooltip isOnline={isOnline} name={editorName} />
+                </motion.div>
+            )}
         </div>
     );
 };

--- a/src/features/user/editor-profile/index.ts
+++ b/src/features/user/editor-profile/index.ts
@@ -1,0 +1,3 @@
+import EditorProfile from './EditorProfile';
+
+export default EditorProfile;


### PR DESCRIPTION
### 📃 변경사항  
- 에디터의 프로필을 보여주는 EditorProfile 컴포넌트 구현
- 에디터들의 프로필 + 에디터 추가 버튼이 들어있는 EditorList 컴포넌트 구현
- GNB에 EditorList 컴포넌트 추가

### 🫨 고민한 부분
- 스타일 먹이는데 마음대로 안돼서 좀 화났네요

### 🎇 동작 화면 
![image](https://github.com/Nexters/audy-client/assets/80266418/1bd36867-a1bd-498d-8f5c-e2d5681fa246)
![image](https://github.com/Nexters/audy-client/assets/80266418/1b69c5f2-52f5-49e0-957d-2200b45de437)

https://github.com/Nexters/audy-client/assets/80266418/85b6257e-8b1c-4833-aae4-7eeba8ba1cb3


### 💫 기타사항 
- 하는김에 tooltip도 광인님이 popover 컴포넌트 만드신 방식대로 compound pattern으로 변경할까 했는데, 지금 그게 급한게 아닌 것 같아서 일단 뒀습니다.
- 지금 구조 수정하는게 좋을 것 같으면 코멘트 주세요
