### PR TITLE
[AUD-97] 새 코스 만들기 기능 구현

### DIFF
--- a/src/apis/course/index.ts
+++ b/src/apis/course/index.ts
@@ -88,12 +88,14 @@ export const CourseRepository = {
     },
 
     async postSaveCourseAsync({
+        userId,
         courseName,
     }: CourseRequestParamType['postSaveCourse']) {
         return postAsync<
             ApiResponseType<CourseResponseType['postSaveCourse']>,
             CourseRequestParamType['postSaveCourse']
         >('/v1/courses', {
+            userId,
             courseName,
         });
     },

--- a/src/apis/course/index.ts
+++ b/src/apis/course/index.ts
@@ -88,14 +88,12 @@ export const CourseRepository = {
     },
 
     async postSaveCourseAsync({
-        userId,
         courseName,
     }: CourseRequestParamType['postSaveCourse']) {
         return postAsync<
             ApiResponseType<CourseResponseType['postSaveCourse']>,
             CourseRequestParamType['postSaveCourse']
         >('/v1/courses', {
-            userId,
             courseName,
         });
     },

--- a/src/apis/course/type.ts
+++ b/src/apis/course/type.ts
@@ -12,7 +12,6 @@ export interface CourseRequestParamType {
         courseName: string;
     };
     postSaveCourse: {
-        userId: number;
         courseName: string;
     };
     deleteCourse: {

--- a/src/apis/course/type.ts
+++ b/src/apis/course/type.ts
@@ -12,7 +12,8 @@ export interface CourseRequestParamType {
         courseName: string;
     };
     postSaveCourse: {
-        courseName: number;
+        userId: number;
+        courseName: string;
     };
     deleteCourse: {
         userId: number;

--- a/src/components/modal/Modal.css.ts
+++ b/src/components/modal/Modal.css.ts
@@ -1,6 +1,7 @@
-import { COLOR } from "@/styles/foundation";
-import { sprinkles } from "@/styles/sprinkle.css";
-import { style } from "@vanilla-extract/css";
+import { style } from '@vanilla-extract/css';
+
+import { COLOR } from '@/styles/foundation';
+import { sprinkles } from '@/styles/sprinkle.css';
 
 export const overlay = style({
     width: '100%',
@@ -10,25 +11,24 @@ export const overlay = style({
     justifyContent: 'center',
     alignItems: 'center',
 
-    backgroundColor: 'rgba(0, 0, 0, 0.33)'
-})
+    backgroundColor: 'rgba(0, 0, 0, 0.33)',
+});
 
 export const header = style({
     width: '100%',
     padding: '8px 0 8px 8px',
-})
+});
 
 export const headerText = style([
-    sprinkles({typography: 'Bold24'}),
+    sprinkles({ typography: 'Bold24' }),
     {
         color: COLOR.Gray900,
-    }
-])
+    },
+]);
 
 export const wrapper = style({
     width: '360px',
     padding: '24px',
-
 
     display: 'flex',
     flexDirection: 'column',
@@ -37,17 +37,18 @@ export const wrapper = style({
     backgroundColor: COLOR.MonoWhite,
     borderRadius: '16px',
     border: `1px solid ${COLOR.Gray200}`,
-    boxShadow: '0 8px 16px rgba(0, 0, 0, 0.03)'
-})
+    boxShadow: '0 8px 16px rgba(0, 0, 0, 0.03)',
+});
 
 export const content = style({
     padding: '8px',
+    width: '100%',
 
     display: 'flex',
     flexDirection: 'column',
 
     textWrap: 'wrap',
-})
+});
 
 export const footer = style({
     width: '100%',
@@ -55,4 +56,4 @@ export const footer = style({
 
     display: 'flex',
     gap: '20px',
-})
+});

--- a/src/features/course/course-name-input/CourseNameInput.css.ts
+++ b/src/features/course/course-name-input/CourseNameInput.css.ts
@@ -39,10 +39,6 @@ export const courseNameSaveButton = style([
     },
 ]);
 
-export const backArrowIcon = style({
-    color: COLOR.Gray900,
-});
-
 export const courseNameEditButton = style({
     color: COLOR.Gray400,
     padding: '4px',
@@ -52,4 +48,8 @@ export const courseNameEditButton = style({
         color: COLOR.Gray800,
         backgroundColor: COLOR.Gray200,
     },
+});
+
+export const goBackButton = style({
+    padding: '0px',
 });

--- a/src/features/course/course-name-input/CourseNameInput.tsx
+++ b/src/features/course/course-name-input/CourseNameInput.tsx
@@ -1,24 +1,26 @@
 import { useState } from 'react';
 
-import { useParams } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 
 import LeftArrowIcon from '@/assets/icons/leftArrow.svg?react';
 import ModifyFilledIcon from '@/assets/icons/modifyFilled.svg?react';
+import { usePatchCourseName } from '@/query-hooks/course/mutation';
 import { useGetCourseDetail } from '@/query-hooks/course/query';
+import { COLOR } from '@/styles/foundation';
 
 import * as S from './CourseNameInput.css';
-import { usePatchCourseName } from '@/query-hooks/course/mutation';
 
 const CourseNameInput = () => {
     const { courseId } = useParams();
+    const navigate = useNavigate();
 
     const {
         data: { courseName },
     } = useGetCourseDetail({ courseId: Number(courseId) });
 
-    const {
-        mutate: updateCourseName,
-    } = usePatchCourseName({ courseId: Number(courseId) })
+    const { mutate: updateCourseName } = usePatchCourseName({
+        courseId: Number(courseId),
+    });
 
     const [isCourseNameEditing, setIsCourseNameEditing] = useState(false);
     const [editedCourseName, setEditedCourseName] = useState(courseName);
@@ -36,11 +38,16 @@ const CourseNameInput = () => {
     return (
         <div className={S.wrapper}>
             {isCourseNameEditing || (
-                <LeftArrowIcon
-                    width={24}
-                    height={24}
-                    className={S.backArrowIcon}
-                />
+                <button
+                    onClick={() => navigate('/')}
+                    className={S.goBackButton}
+                >
+                    <LeftArrowIcon
+                        width={24}
+                        height={24}
+                        fill={COLOR.Gray900}
+                    />
+                </button>
             )}
 
             {isCourseNameEditing ? (

--- a/src/features/course/make-new-course-modal/MakeNewCourseModal.css.ts
+++ b/src/features/course/make-new-course-modal/MakeNewCourseModal.css.ts
@@ -1,0 +1,50 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { COLOR } from '@/styles/foundation';
+import { sprinkles } from '@/styles/sprinkle.css';
+
+export const modalHeader = style({
+    width: '100%',
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+});
+
+export const couseNameInput = style({
+    border: `1px solid ${COLOR.Gray200}`,
+    width: '100%',
+    flex: 1,
+    padding: '16px',
+    borderRadius: '6px',
+});
+
+export const saveButton = recipe({
+    base: [
+        sprinkles({ typography: 'Bold17' }),
+        {
+            height: '56px',
+            flex: 1,
+            textAlign: 'center',
+            borderRadius: '10px',
+            backgroundColor: COLOR.Gray900,
+            color: COLOR.MonoWhite,
+        },
+    ],
+    variants: {
+        isButtonDisabled: {
+            true: {
+                backgroundColor: COLOR.Gray300,
+                cursor: 'default',
+            },
+            false: {
+                backgroundColor: COLOR.Gray900,
+            },
+        },
+    },
+});
+
+export const modalCloseButton = style({
+    padding: '6px',
+    color: COLOR.Gray400,
+});

--- a/src/features/course/make-new-course-modal/MakeNewCourseModal.tsx
+++ b/src/features/course/make-new-course-modal/MakeNewCourseModal.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import CloseIcon from '@/assets/icons/close.svg?react';
+import Modal from '@/components/modal/Modal';
+import { useModal } from '@/hooks/useModal';
+import { useToast } from '@/hooks/useToast';
+import { usePostSaveCourse } from '@/query-hooks/course/mutation';
+
+import * as S from './MakeNewCourseModal.css';
+
+interface PropsType {
+    userId: number;
+}
+
+const MakeNewCourseModal = ({ userId }: PropsType) => {
+    const [isButtonDisabled, setIsButtonDisabled] = useState(false);
+    const [courseName, setCourseName] = useState('새로운 코스');
+
+    const { closeModal } = useModal();
+    const { setToast } = useToast();
+    const { mutateAsync: makeNewCourse } = usePostSaveCourse({ userId });
+
+    const navigate = useNavigate();
+
+    const handleSaveButtonClick = async () => {
+        const { data } = await makeNewCourse(courseName);
+
+        closeModal();
+        setToast('새 코스가 만들어졌어요');
+        navigate(`/course/${data.courseId}`);
+    };
+
+    const handleNewCourseNameChange = ({
+        target,
+    }: React.ChangeEvent<HTMLInputElement>) => {
+        if (!target.value) setIsButtonDisabled(true);
+        else setIsButtonDisabled(false);
+
+        setCourseName(target.value);
+    };
+
+    return (
+        <Modal>
+            <div className={S.modalHeader}>
+                <Modal.Title>코스명 수정</Modal.Title>
+                <button className={S.modalCloseButton} onClick={closeModal}>
+                    <CloseIcon width={28} height={28} />
+                </button>
+            </div>
+
+            <Modal.Content>
+                <input
+                    className={S.couseNameInput}
+                    value={courseName}
+                    onChange={handleNewCourseNameChange}
+                />
+            </Modal.Content>
+
+            <Modal.Footer>
+                <button
+                    className={S.saveButton({ isButtonDisabled })}
+                    onClick={handleSaveButtonClick}
+                    disabled={isButtonDisabled}
+                >
+                    저장
+                </button>
+            </Modal.Footer>
+        </Modal>
+    );
+};
+
+export default MakeNewCourseModal;

--- a/src/features/course/make-new-course-modal/MakeNewCourseModal.tsx
+++ b/src/features/course/make-new-course-modal/MakeNewCourseModal.tsx
@@ -10,17 +10,13 @@ import { usePostSaveCourse } from '@/query-hooks/course/mutation';
 
 import * as S from './MakeNewCourseModal.css';
 
-interface PropsType {
-    userId: number;
-}
-
-const MakeNewCourseModal = ({ userId }: PropsType) => {
+const MakeNewCourseModal = () => {
     const [isButtonDisabled, setIsButtonDisabled] = useState(false);
     const [courseName, setCourseName] = useState('새로운 코스');
 
     const { closeModal } = useModal();
     const { setToast } = useToast();
-    const { mutateAsync: makeNewCourse } = usePostSaveCourse({ userId });
+    const { mutateAsync: makeNewCourse } = usePostSaveCourse({});
 
     const navigate = useNavigate();
 

--- a/src/features/course/make-new-course-modal/MakeNewCourseModal.tsx
+++ b/src/features/course/make-new-course-modal/MakeNewCourseModal.tsx
@@ -40,7 +40,7 @@ const MakeNewCourseModal = () => {
     return (
         <Modal>
             <div className={S.modalHeader}>
-                <Modal.Title>코스명 수정</Modal.Title>
+                <Modal.Title>새 코스 추가</Modal.Title>
                 <button className={S.modalCloseButton} onClick={closeModal}>
                     <CloseIcon width={28} height={28} />
                 </button>

--- a/src/features/course/make-new-course-modal/index.ts
+++ b/src/features/course/make-new-course-modal/index.ts
@@ -1,0 +1,3 @@
+import MakeNewCourseModal from './MakeNewCourseModal';
+
+export default MakeNewCourseModal;

--- a/src/pages/main/MainPage.css.ts
+++ b/src/pages/main/MainPage.css.ts
@@ -24,8 +24,14 @@ export const addNewCourseButton = style({
     justifyContent: 'center',
     gap: '12px',
     backgroundColor: COLOR.MonoWhite,
-    padding: '21px',
-    borderRadius: '16px',
+    padding: '14px',
+    borderRadius: '6px',
+    border: `1px solid ${COLOR.Gray200}`,
+    transition: 'background-color 0.2s',
+
+    ':hover': {
+        backgroundColor: COLOR.Gray200,
+    },
 });
 
 export const addNewCourseButtonText = style([

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -9,7 +9,6 @@ import CoursesContainer from '@/features/course/courses-container';
 import MakeNewCourseModal from '@/features/course/make-new-course-modal';
 import { useModal } from '@/hooks/useModal';
 import { useTmap } from '@/hooks/useTmap';
-import { useGetUserInformation } from '@/query-hooks/user/query';
 import { CourseTabType } from '@/types';
 
 import * as S from './MainPage.css';
@@ -17,7 +16,6 @@ import * as S from './MainPage.css';
 const MainPage = () => {
     const { mapContainerRef } = useTmap();
     const { openModal } = useModal();
-    const { data: userInformation } = useGetUserInformation({});
 
     const [selectedCourseTab, setSelectedCourseTab] =
         useState<CourseTabType>('allCourse');
@@ -27,7 +25,7 @@ const MainPage = () => {
     };
 
     const handleMakeNewCourse = async () => {
-        openModal(<MakeNewCourseModal userId={userInformation.userId} />);
+        openModal(<MakeNewCourseModal />);
     };
 
     return (

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,15 +1,14 @@
 import { useState } from 'react';
 
-import { useNavigate } from 'react-router-dom';
-
 import AddIcon from '@/assets/icons/add.svg?react';
 import AsyncBoundary from '@/components/async-boundary';
 import GlobalNavigationBar from '@/components/global-navigation-bar';
 import SidePanel from '@/components/side-panel';
 import CourseFilteringTab from '@/features/course/course-filtering-tab/CourseFilteringTab';
 import CoursesContainer from '@/features/course/courses-container';
+import MakeNewCourseModal from '@/features/course/make-new-course-modal';
+import { useModal } from '@/hooks/useModal';
 import { useTmap } from '@/hooks/useTmap';
-import { usePostSaveCourse } from '@/query-hooks/course/mutation';
 import { useGetUserInformation } from '@/query-hooks/user/query';
 import { CourseTabType } from '@/types';
 
@@ -17,12 +16,8 @@ import * as S from './MainPage.css';
 
 const MainPage = () => {
     const { mapContainerRef } = useTmap();
-    const navigate = useNavigate();
-
+    const { openModal } = useModal();
     const { data: userInformation } = useGetUserInformation({});
-    const { mutateAsync: makeNewCourse } = usePostSaveCourse({
-        userId: userInformation.userId,
-    });
 
     const [selectedCourseTab, setSelectedCourseTab] =
         useState<CourseTabType>('allCourse');
@@ -32,8 +27,7 @@ const MainPage = () => {
     };
 
     const handleMakeNewCourse = async () => {
-        const response = await makeNewCourse('새로운 코스');
-        navigate(`/course/${response.data.courseId}`);
+        openModal(<MakeNewCourseModal userId={userInformation.userId} />);
     };
 
     return (

--- a/src/pages/main/MainPage.tsx
+++ b/src/pages/main/MainPage.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
+
 import AddIcon from '@/assets/icons/add.svg?react';
 import AsyncBoundary from '@/components/async-boundary';
 import GlobalNavigationBar from '@/components/global-navigation-bar';
@@ -7,18 +9,31 @@ import SidePanel from '@/components/side-panel';
 import CourseFilteringTab from '@/features/course/course-filtering-tab/CourseFilteringTab';
 import CoursesContainer from '@/features/course/courses-container';
 import { useTmap } from '@/hooks/useTmap';
+import { usePostSaveCourse } from '@/query-hooks/course/mutation';
+import { useGetUserInformation } from '@/query-hooks/user/query';
 import { CourseTabType } from '@/types';
 
 import * as S from './MainPage.css';
 
 const MainPage = () => {
     const { mapContainerRef } = useTmap();
+    const navigate = useNavigate();
+
+    const { data: userInformation } = useGetUserInformation({});
+    const { mutateAsync: makeNewCourse } = usePostSaveCourse({
+        userId: userInformation.userId,
+    });
 
     const [selectedCourseTab, setSelectedCourseTab] =
         useState<CourseTabType>('allCourse');
 
     const handleCourseTabClick = (tab: CourseTabType) => {
         setSelectedCourseTab(tab);
+    };
+
+    const handleMakeNewCourse = async () => {
+        const response = await makeNewCourse('새로운 코스');
+        navigate(`/course/${response.data.courseId}`);
     };
 
     return (
@@ -32,7 +47,10 @@ const MainPage = () => {
                         handleCourseTabClick={handleCourseTabClick}
                     />
 
-                    <button className={S.addNewCourseButton}>
+                    <button
+                        className={S.addNewCourseButton}
+                        onClick={handleMakeNewCourse}
+                    >
                         <AddIcon fill="#000000" width={20} height={20} />
                         <p className={S.addNewCourseButtonText}>
                             새로운 코스 만들기

--- a/src/query-hooks/course/mutation.ts
+++ b/src/query-hooks/course/mutation.ts
@@ -1,8 +1,13 @@
-import { type UseMutationOptions, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+    type UseMutationOptions,
+    useMutation,
+    useQueryClient,
+} from '@tanstack/react-query';
+import type { AxiosError } from 'axios';
 
 import { CourseRepository } from '@/apis/course';
 import type { CourseRequestParamType } from '@/apis/course/type';
-import type { AxiosError } from 'axios';
+
 import { COURSE_QUERY_KEY } from './key';
 
 // 특정 코스를 삭제하는 Hook useDeleteCourse
@@ -10,11 +15,13 @@ export const useDeleteCourse = ({
     userId,
     courseId,
     ...options
-}: CourseRequestParamType['deleteCourse'] & UseMutationOptions<void, AxiosError>) => {
+}: CourseRequestParamType['deleteCourse'] &
+    UseMutationOptions<void, AxiosError>) => {
     const queryClient = useQueryClient();
     return useMutation({
         ...options,
-        mutationFn: () => CourseRepository.deleteCourseAsync({ userId, courseId }),
+        mutationFn: () =>
+            CourseRepository.deleteCourseAsync({ userId, courseId }),
         onSuccess: () => {
             queryClient.removeQueries({
                 queryKey: COURSE_QUERY_KEY.detail(courseId),
@@ -32,10 +39,32 @@ export const usePatchCourseName = ({
     const queryClient = useQueryClient();
     return useMutation({
         ...options,
-        mutationFn: (courseName: string) => CourseRepository.patchUpdateCourseAsync({ courseId, courseName }),
+        mutationFn: (courseName: string) =>
+            CourseRepository.patchUpdateCourseAsync({ courseId, courseName }),
         onSuccess: () => {
             queryClient.invalidateQueries({
                 queryKey: COURSE_QUERY_KEY.detail(courseId),
+            });
+        },
+        throwOnError: true,
+    });
+};
+
+// 새로운 코스를 만드는 Hook usePostSaveCourse
+export const usePostSaveCourse = ({
+    userId,
+    ...options
+}: {
+    userId: number;
+}) => {
+    const queryClient = useQueryClient();
+    return useMutation({
+        ...options,
+        mutationFn: (courseName: string) =>
+            CourseRepository.postSaveCourseAsync({ userId, courseName }),
+        onSuccess: () => {
+            queryClient.invalidateQueries({
+                queryKey: COURSE_QUERY_KEY.list(),
             });
         },
         throwOnError: true,

--- a/src/query-hooks/course/mutation.ts
+++ b/src/query-hooks/course/mutation.ts
@@ -51,17 +51,12 @@ export const usePatchCourseName = ({
 };
 
 // 새로운 코스를 만드는 Hook usePostSaveCourse
-export const usePostSaveCourse = ({
-    userId,
-    ...options
-}: {
-    userId: number;
-}) => {
+export const usePostSaveCourse = ({ ...options }) => {
     const queryClient = useQueryClient();
     return useMutation({
         ...options,
         mutationFn: (courseName: string) =>
-            CourseRepository.postSaveCourseAsync({ userId, courseName }),
+            CourseRepository.postSaveCourseAsync({ courseName }),
         onSuccess: () => {
             queryClient.invalidateQueries({
                 queryKey: COURSE_QUERY_KEY.list(),

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,7 +1,7 @@
 export type SocialPlatformType = 'apple' | 'kakao';
 
 export interface UserType {
-    userId: string;
+    userId: number;
     email: string;
     username: string;
     imageUrl: string;


### PR DESCRIPTION
### 📃 변경사항  
- 새로운 코스 만들기 버튼 스타일 수정
- 새로운 코스 만들기 기능 구현
  - 일단은 모달이 구현되기 전이라 
  - 클릭했을 때 '새로운 코스' 라는 제목으로 새 코스가 만들어지고, 바로 그 코스로 진입하도록 했습니다. 
- course page의 뒤로가기 버튼 기능 추가
- usePostSaveCourse hook 구현
- postSaveCourseAsync에 userId를 파라미터로 추가
- UserType의 userId 타입을 number로 변경

### 🫨 고민한 부분 
- usePostSaveCourse hook 부분
  - 혹시 잘못된게 있으면 코멘트 부탁드립니다 

### 🎇 동작 화면
https://github.com/Nexters/audy-client/assets/80266418/65584dbd-f143-463f-8f11-e3da6c6e989c

### 💫 기타사항 (optional)  
- useNavigate로 페이지 이동할 때 지도가 보이지 않는 문제가 있습니다.
- 이 부분은 별도 PR로 분리해서 해결하도록 하겠습니다