### PR TITLE
[AUD-105] 메인페이지에서 코스 진입 로직 추가

### DIFF
--- a/src/components/pop-over/PopOverTrigger.tsx
+++ b/src/components/pop-over/PopOverTrigger.tsx
@@ -22,9 +22,10 @@ const PopOverTrigger = ({
     };
 
     const handlePopOverTrigger = (event: MouseEvent<HTMLDivElement>) => {
+        event.stopPropagation();
         onClick?.(event);
         togglePopOver();
-    }
+    };
 
     return (
         <div

--- a/src/features/course/course-tab/CourseTab.css.ts
+++ b/src/features/course/course-tab/CourseTab.css.ts
@@ -11,7 +11,6 @@ export const layout = style({
     padding: '17px 24px',
     width: '100%',
     backgroundColor: COLOR.MonoWhite,
-    borderRadius: '42px',
     cursor: 'pointer',
 
     ':hover': {

--- a/src/features/course/course-tab/CourseTab.tsx
+++ b/src/features/course/course-tab/CourseTab.tsx
@@ -1,3 +1,5 @@
+import { useNavigate } from 'react-router-dom';
+
 import MyCourseIcon from '@/assets/icons/myCourse.svg?react';
 import PersonIcon from '@/assets/icons/person.svg?react';
 import PinIcon from '@/assets/icons/pin.svg?react';
@@ -21,8 +23,14 @@ const CourseTab = ({
     pinCount,
     isMyCourse,
 }: PropsType) => {
+    const navigate = useNavigate();
+
+    const handleMoveToCourse = () => {
+        navigate(`/course/${courseId}`);
+    };
+
     return (
-        <div className={S.layout}>
+        <div className={S.layout} onClick={handleMoveToCourse}>
             <div>
                 <div className={S.courseNameContainer}>
                     {isMyCourse && <MyCourseIcon fill={COLOR.PinkPrimary} />}

--- a/src/features/course/courses-container/CoursesContainer.css.ts
+++ b/src/features/course/courses-container/CoursesContainer.css.ts
@@ -7,12 +7,12 @@ export const layout = style({
     flexDirection: 'column',
     height: '100%',
     overflowY: 'auto',
-    padding: '16px',
-    borderRadius: '16px',
+    padding: '16px 0',
+    borderRadius: '6px',
     backgroundColor: COLOR.MonoWhite,
 });
 
 export const lastChildren = style({
     width: '100%',
     height: '8px',
-})
+});

--- a/src/features/path/path-item/PathItem.css.ts
+++ b/src/features/path/path-item/PathItem.css.ts
@@ -17,7 +17,6 @@ export const wrapper = recipe({
     variants: {
         status: {
             selected: {
-                borderRadius: '100px',
                 backgroundColor: `${COLOR.MonoBlack}08`,
             },
             none: {},

--- a/src/features/path/path-view/PathView.css.ts
+++ b/src/features/path/path-view/PathView.css.ts
@@ -4,7 +4,7 @@ import { COLOR } from '@/styles/foundation';
 
 export const wrapper = style({
     height: '100%',
-    padding: '12px 8px',
+    padding: '12px 0',
 
     display: 'flex',
     flexDirection: 'column',
@@ -12,11 +12,11 @@ export const wrapper = style({
     backgroundColor: COLOR.MonoWhite,
     overflowY: 'scroll',
 
-    "::-webkit-scrollbar": {
+    '::-webkit-scrollbar': {
         width: '8px',
     },
 
-    "::-webkit-scrollbar-thumb": {
+    '::-webkit-scrollbar-thumb': {
         width: '3px',
 
         backgroundClip: 'padding-box',

--- a/src/features/search/search-result-tab/SearchResultTab.css.ts
+++ b/src/features/search/search-result-tab/SearchResultTab.css.ts
@@ -8,7 +8,7 @@ export const layout = style({
     justifyContent: 'space-between',
     backgroundColor: COLOR.MonoWhite,
     padding: '15px 16px 13px 24px',
-    borderRadius: '6px',
+
     cursor: 'pointer',
 
     ':hover': {

--- a/src/features/search/search-results-container/SearchResultsContainer.css.ts
+++ b/src/features/search/search-results-container/SearchResultsContainer.css.ts
@@ -8,19 +8,19 @@ export const layout = style({
     flexDirection: 'column',
     height: '100%',
     overflowY: 'auto',
-    padding: '12px 8px',
+    padding: '12px 0',
     backgroundColor: COLOR.MonoWhite,
 });
 
 export const observer = style({
     width: '100%',
     height: '4px',
-})
+});
 
 export const emptyNotice = style([
     sprinkles({ typography: 'Medium14' }),
     {
         margin: 'auto',
         color: COLOR.Gray400,
-    }
-])
+    },
+]);


### PR DESCRIPTION
### 📃 변경사항  
- 메인페이지에서 코스 탭 클릭 시 해당 코스로 진입하는 로직 구현
- PopOverTrigger에 event.stopPropagation 추가
- 코스 탭 / 경로 탭 / 검색 탭 부분 자잘한 디자인 수정
  - 따로 PR로 뺄까했는데 너무 단위가 작아서 그냥 같이 넣었습니다. 

### 🎇 동작 화면 
![image](https://github.com/Nexters/audy-client/assets/80266418/4046634a-e143-4f7e-8d61-bdb77b43b1c4)


### 💫 기타사항 
- PopOverTrigger를 아래와 같이 사용하시는걸 보면 PopOverTrigger 자체를 div가 아니라 button으로 만드는게 좋을 것 같은데 광인님 생각은 어떠신가요? 
```
<PopOver.Trigger>
  <SettingIcon className={S.settingIcon} />
</PopOver.Trigger>
```