### PR TITLE
[AUD-115] 경로 탭에서 핀 삭제 기능 구현

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -9,7 +9,7 @@ declare global {
     }
 
     interface CustomEventMap {
-        'marker:create': CustomEvent<MarkerType>;
+        'marker:create': CustomEvent<{ marker: MarkerType; index: number }>;
         'marker:remove': CustomEvent<string>;
     }
 

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,11 +1,7 @@
-import axios, {
-    type AxiosError,
-    type AxiosRequestConfig,
-    type AxiosResponse,
-} from 'axios';
+import axios, { type AxiosRequestConfig, type AxiosResponse } from 'axios'; // type AxiosError,
 
-import { STATUS_CODE } from '@/constants/status';
-import { ApiError } from '@/utils/error/ApiError';
+// import { STATUS_CODE } from '@/constants/status';
+// import { ApiError } from '@/utils/error/ApiError';
 
 /**
  * 백엔드로부터 인계 받은 응답의 기본 Interface ApiResponseType

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -26,35 +26,35 @@ const API = axios.create({
     withCredentials: true,
 });
 
-API.interceptors.response.use(
-    (response: AxiosResponse<ApiResponseType<unknown>>) => {
-        const { code, data, message } = response.data;
+// API.interceptors.response.use(
+//     (response: AxiosResponse<ApiResponseType<unknown>>) => {
+//         const { code, data, message } = response.data;
 
-        if (code !== STATUS_CODE.OK) {
-            throw new ApiError({ code, data, message });
-        }
+//         if (code !== STATUS_CODE.OK) {
+//             throw new ApiError({ code, data, message });
+//         }
 
-        return response;
-    },
-    (error: AxiosError | Error): Promise<ApiError> => {
-        if (axios.isAxiosError(error)) {
-            if (error.response) {
-                throw new ApiError({
-                    code: STATUS_CODE.NETWORK_ERROR,
-                    data: null,
-                    message:
-                        error.response?.data ??
-                        '알 수 없는 에러가 발생했습니다',
-                });
-            }
-        }
-        throw new ApiError({
-            code: STATUS_CODE.NETWORK_ERROR,
-            data: null,
-            message: '알 수 없는 에러가 발생했습니다',
-        });
-    },
-);
+//         return response;
+//     },
+//     (error: AxiosError | Error): Promise<ApiError> => {
+//         if (axios.isAxiosError(error)) {
+//             if (error.response) {
+//                 throw new ApiError({
+//                     code: STATUS_CODE.NETWORK_ERROR,
+//                     data: null,
+//                     message:
+//                         error.response?.data ??
+//                         '알 수 없는 에러가 발생했습니다',
+//                 });
+//             }
+//         }
+//         throw new ApiError({
+//             code: STATUS_CODE.NETWORK_ERROR,
+//             data: null,
+//             message: '알 수 없는 에러가 발생했습니다',
+//         });
+//     },
+// );
 
 /**
  * GET 요청을 처리하는 유틸 API 함수 getAsync

--- a/src/components/pop-over/PopOver.css.ts
+++ b/src/components/pop-over/PopOver.css.ts
@@ -9,6 +9,7 @@ export const wrapper = style({
 export const trigger = style({
     width: 'fit-content',
     height: 'fit-content',
+    cursor: 'pointer',
 });
 
 export const content = style({
@@ -23,12 +24,12 @@ export const content = style({
     zIndex: Z_INDEX.popOver,
     bottom: '4px',
     right: '0',
-    
+
     backgroundColor: COLOR.MonoWhite,
     border: `1px solid ${COLOR.Gray200}`,
     borderRadius: '15px',
     boxShadow: `0px 10px 20px 0px rgba(0, 0, 0, 0.12)`,
-    transform: 'translate(0, 100%)'
+    transform: 'translate(0, 100%)',
 });
 
 export const item = style({

--- a/src/features/path/path-item/ThreeDotButton.tsx
+++ b/src/features/path/path-item/ThreeDotButton.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import EditIcon from '@/assets/icons/edit.svg?react';
 import EyeClosedIcon from '@/assets/icons/eyeClosed.svg?react';
 import EyeOpenedIcon from '@/assets/icons/eyeOpened.svg?react';
@@ -5,7 +7,9 @@ import ThreeDotIcon from '@/assets/icons/threeDot.svg?react';
 import TrashCanIcon from '@/assets/icons/trashCan.svg?react';
 import PopOver from '@/components/pop-over';
 import { useDisclosure } from '@/hooks/useDisclosure';
+import { useSnackBar } from '@/hooks/useSnackBar';
 import { useTmap } from '@/hooks/useTmap';
+import { MarkerType } from '@/types';
 
 import * as S from './ThreeDotButton.css';
 
@@ -15,6 +19,7 @@ interface PropsType {
 
 const ThreeDotButton = ({ markerId }: PropsType) => {
     const { tmapModuleRef } = useTmap();
+    const { setSnackBar } = useSnackBar();
 
     const initPinHided =
         !!tmapModuleRef.current?.getMarkerInfoFromId(markerId)?.isHidden;
@@ -22,25 +27,71 @@ const ThreeDotButton = ({ markerId }: PropsType) => {
     const { value: isPinHided, toggle: togglePinHided } =
         useDisclosure(initPinHided);
 
-    const handlePinHide = () => {
+    const handleHidePin = () => {
         if (!tmapModuleRef.current) return;
         tmapModuleRef.current.toggleMarkerHiddenState(markerId);
         togglePinHided();
     };
+
+    const [removedPin, setRemovedPin] = useState({
+        marker: {} as MarkerType,
+        index: 0,
+    });
+
+    const handleRecreateRemovedPin = ({
+        marker: { name, originName, address, lat, lng, id },
+        index,
+    }: {
+        marker: MarkerType;
+        index: number;
+    }) => {
+        tmapModuleRef.current?.createMarker({
+            name: name,
+            originName: originName,
+            address: address,
+            lat: lat,
+            lng: lng,
+            id: id,
+            index,
+        });
+    };
+
+    const handleRemovePin = () => {
+        if (!tmapModuleRef.current) return;
+
+        const { marker, index } = tmapModuleRef.current.removeMarker(markerId);
+        setRemovedPin({ marker, index });
+
+        // setSnackBar({
+        //     message: '핀이 삭제되었어요',
+        //     undoFunction: () => handleRecreateRemovedPin({ ...removedPin }),
+        // });
+    };
+
+    useEffect(() => {
+        console.log(removedPin);
+        if (removedPin.marker.id) {
+            setSnackBar({
+                message: '핀이 삭제되었어요',
+                undoFunction: () => handleRecreateRemovedPin({ ...removedPin }),
+            });
+        }
+    }, [removedPin, setSnackBar, handleRecreateRemovedPin, setRemovedPin]);
 
     return (
         <PopOver>
             <PopOver.Trigger className={S.threeDotButton}>
                 <ThreeDotIcon />
             </PopOver.Trigger>
+
             <PopOver.Content>
                 {isPinHided ? (
-                    <PopOver.Item onClick={handlePinHide}>
+                    <PopOver.Item onClick={handleHidePin}>
                         <EyeOpenedIcon />
                         <p className={S.text}>경로에서 보이기</p>
                     </PopOver.Item>
                 ) : (
-                    <PopOver.Item onClick={handlePinHide}>
+                    <PopOver.Item onClick={handleHidePin}>
                         <EyeClosedIcon />
                         <p className={S.text}>경로에서 숨기기</p>
                     </PopOver.Item>
@@ -51,7 +102,7 @@ const ThreeDotButton = ({ markerId }: PropsType) => {
                     <p className={S.text}>장소명 수정</p>
                 </PopOver.Item>
 
-                <PopOver.Item>
+                <PopOver.Item onClick={handleRemovePin}>
                     <TrashCanIcon />
                     <p className={S.text}>장소 삭제</p>
                 </PopOver.Item>

--- a/src/features/path/path-item/ThreeDotButton.tsx
+++ b/src/features/path/path-item/ThreeDotButton.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-
 import EditIcon from '@/assets/icons/edit.svg?react';
 import EyeClosedIcon from '@/assets/icons/eyeClosed.svg?react';
 import EyeOpenedIcon from '@/assets/icons/eyeOpened.svg?react';
@@ -9,7 +7,6 @@ import PopOver from '@/components/pop-over';
 import { useDisclosure } from '@/hooks/useDisclosure';
 import { useSnackBar } from '@/hooks/useSnackBar';
 import { useTmap } from '@/hooks/useTmap';
-import { MarkerType } from '@/types';
 
 import * as S from './ThreeDotButton.css';
 
@@ -33,50 +30,29 @@ const ThreeDotButton = ({ markerId }: PropsType) => {
         togglePinHided();
     };
 
-    const [removedPin, setRemovedPin] = useState({
-        marker: {} as MarkerType,
-        index: 0,
-    });
-
-    const handleRecreateRemovedPin = ({
-        marker: { name, originName, address, lat, lng, id },
-        index,
-    }: {
-        marker: MarkerType;
-        index: number;
-    }) => {
-        tmapModuleRef.current?.createMarker({
-            name: name,
-            originName: originName,
-            address: address,
-            lat: lat,
-            lng: lng,
-            id: id,
-            index,
-        });
-    };
-
     const handleRemovePin = () => {
         if (!tmapModuleRef.current) return;
 
-        const { marker, index } = tmapModuleRef.current.removeMarker(markerId);
-        setRemovedPin({ marker, index });
+        const {
+            marker: { name, originName, address, lat, lng, id },
+            index,
+        } = tmapModuleRef.current.removeMarker(markerId);
 
-        // setSnackBar({
-        //     message: '핀이 삭제되었어요',
-        //     undoFunction: () => handleRecreateRemovedPin({ ...removedPin }),
-        // });
+        setSnackBar({
+            message: '핀이 삭제되었어요',
+            undoFunction: () => {
+                tmapModuleRef.current?.createMarker({
+                    name: name,
+                    originName: originName,
+                    address: address,
+                    lat: lat,
+                    lng: lng,
+                    id: id,
+                    index,
+                });
+            },
+        });
     };
-
-    useEffect(() => {
-        console.log(removedPin);
-        if (removedPin.marker.id) {
-            setSnackBar({
-                message: '핀이 삭제되었어요',
-                undoFunction: () => handleRecreateRemovedPin({ ...removedPin }),
-            });
-        }
-    }, [removedPin, setSnackBar, handleRecreateRemovedPin, setRemovedPin]);
 
     return (
         <PopOver>

--- a/src/utils/tmap/tmapModule.tsx
+++ b/src/utils/tmap/tmapModule.tsx
@@ -177,10 +177,12 @@ export class TMapModule {
             (marker) => marker.id === id,
         );
 
-        const [{ marker: targetMarker }] = this.#markers.splice(markerIndex, 1);
-        targetMarker.setMap(null);
+        const targetMarker = this.#markers.splice(markerIndex, 1)[0];
+        targetMarker.marker.setMap(null);
 
         window.dispatchEvent(new CustomEvent('marker:remove', { detail: id }));
+
+        return { marker: targetMarker, index: markerIndex };
     }
 
     // 마커 수정

--- a/src/utils/tmap/tmapModule.tsx
+++ b/src/utils/tmap/tmapModule.tsx
@@ -161,7 +161,7 @@ export class TMapModule {
 
         window.dispatchEvent(
             new CustomEvent('marker:create', {
-                detail: newMarker,
+                detail: { marker: newMarker, index },
             }),
         );
 

--- a/src/utils/tmap/tmapModule.tsx
+++ b/src/utils/tmap/tmapModule.tsx
@@ -116,6 +116,7 @@ export class TMapModule {
         iconHTML = renderToString(
             <Marker order={this.#markers.length + 1} isHidden={false} />,
         ),
+        index = this.#markers.length,
     }: {
         name: string;
         originName: string;
@@ -124,6 +125,7 @@ export class TMapModule {
         lat: string;
         lng: string;
         iconHTML?: string;
+        index?: number;
     }) {
         if (this.#markers.length >= this.#maxMarkerCount) return;
 
@@ -155,7 +157,7 @@ export class TMapModule {
 
         newMarker.marker.on('Click', handleMarkerClick);
 
-        this.#markers.push(newMarker);
+        this.#markers.splice(index, 0, newMarker);
 
         window.dispatchEvent(
             new CustomEvent('marker:create', {

--- a/src/utils/tmap/tmapModule.tsx
+++ b/src/utils/tmap/tmapModule.tsx
@@ -166,6 +166,7 @@ export class TMapModule {
         );
 
         this.drawPathBetweenMarkers();
+        this.modifyMarker(this.#markers);
         this.clusterMarkers();
 
         return newMarker;
@@ -179,6 +180,7 @@ export class TMapModule {
 
         const targetMarker = this.#markers.splice(markerIndex, 1)[0];
         targetMarker.marker.setMap(null);
+        this.modifyMarker(this.#markers);
 
         window.dispatchEvent(new CustomEvent('marker:remove', { detail: id }));
 
@@ -374,8 +376,6 @@ export class TMapModule {
         const handleUnPinButtonClick = () => {
             this.removeMarker(id);
             this.removeInfoWindow();
-
-            this.modifyMarker(this.#markers);
         };
 
         document


### PR DESCRIPTION
### 📃 변경사항  
- 경로탭에서 쓰리닷 -> 장소 삭제 클릭 시 해당 장소 사라지도록 구현
  - 스낵낵바의 실행취소를 누르면 해당 장소가 다시 생김 
- createMarker에서 index도 받도록 수정
  - 기존에는 배열의 맨 뒤에 push되는 형식이었는데, 배열의 중간에 끼워넣을 수 있도록 index도 받도록 했습니다.
- marker:create 커스텀 이벤트에 index도 같이 전달하도록 수정

### 🫨 고민한 부분
- 장소 삭제 시 스낵바를 띄우는 부분에서 아래와 같은 에러가 계속 발생했습니다.
  - `Warning: Cannot update a component (PathView) while rendering a different component (SnackBarProvider). To locate the bad setState() call inside SnackBarProvider`
  - 이 부분 때문에 몇 시간 삽질했는데.. ㅜ AUD-92 merge하고 rebase 하니까 해결이 되더라구요.  .. 쩝 
   설마했는데 진짜 될줄이야...

### 🎇 동작 화면
https://github.com/Nexters/audy-client/assets/80266418/b19d4f3b-f44b-47fd-b9de-df7a014d679c

### 💫 기타사항
- 현재 마커에 인포창이 떠 있는 상태로 탭을 통해 마커를 삭제하면 인포창이 그대로 남아있는 문제가 있습니다.
- 이건 지라 이슈로 따로 올려두었습니다 