### PR TITLE
[AUD-100] TmapModule 과 WebSocket 간의 기능 연동

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,3 +1,4 @@
+import type { CourseSocketPubType } from '@/apis/course/type';
 import type { MarkerType } from '@/types/map';
 
 // T-MAP API NameSpace
@@ -11,7 +12,10 @@ declare global {
     interface CustomEventMap {
         'marker:create': CustomEvent<MarkerType>;
         'marker:remove': CustomEvent<string>;
-        'duration:update': CustomEvent<number>
+        'infoWindow:confirm': CustomEvent<
+            Omit<CourseSocketPubType['addition'], 'courseId'>
+        >;
+        'duration:update': CustomEvent<number>;
     }
 
     interface WindowEventMap extends CustomEventMap {}

--- a/global.d.ts
+++ b/global.d.ts
@@ -15,6 +15,7 @@ declare global {
         'infoWindow:confirm': CustomEvent<
             Omit<CourseSocketPubType['addition'], 'courseId'>
         >;
+        'infoWindow:revert': CustomEvent<string>,
         'duration:update': CustomEvent<number>;
     }
 

--- a/src/apis/course/type.ts
+++ b/src/apis/course/type.ts
@@ -49,15 +49,15 @@ export interface CourseSocketPubType {
         latitude: number;
         longitude: number;
         address: string;
-        sequence: number;
+        sequence: string;
     };
-    modificationName: {
+    modifyName: {
         pinId: string;
         pinName: string;
     };
-    modificationOrder: {
+    modifySequence: {
         pinId: string;
-        sequence: number;
+        sequence: string;
     };
     removal: {
         pinId: string;
@@ -73,15 +73,15 @@ export interface CourseSocketSubType {
         latitude: number;
         longitude: number;
         address: string;
-        sequence: number;
+        sequence: string;
     };
-    modificationName: {
+    modifyName: {
         pinId: string;
         pinName: string;
     };
-    modificationOrder: {
+    modifySequence: {
         pinId: string;
-        sequence: number;
+        sequence: string;
     };
     removal: {
         pinId: string;

--- a/src/apis/course/type.ts
+++ b/src/apis/course/type.ts
@@ -46,8 +46,8 @@ export interface CourseSocketPubType {
         courseId: number;
         pinName: string;
         originName: string;
-        latitude: number;
-        longitude: number;
+        latitude: string;
+        longitude: string;
         address: string;
         sequence: string;
     };
@@ -70,8 +70,8 @@ export interface CourseSocketSubType {
         pinId: string;
         pinName: string;
         originName: string;
-        latitude: number;
-        longitude: number;
+        latitude: string;
+        longitude: string;
         address: string;
         sequence: string;
     };

--- a/src/features/map/float-menu/FloatMenu.tsx
+++ b/src/features/map/float-menu/FloatMenu.tsx
@@ -11,22 +11,22 @@ import dayjs from '@/utils/dayjs';
 import * as S from './FloatMenu.css';
 
 const FloatMenu = () => {
-    const { tmapModuleRef } = useTmap();
+    const { tmapModule } = useTmap();
     const { value: isShowPath, toggle: toggleShowPath } = useDisclosure(true);
 
     const [pathType, setPathType] = useState<PathModeType>('Vehicle');
     const [currentDuration, setCurrentDuration] = useState<number | null>(null);
 
     const handleChangePathMode = async (updatedMode: PathModeType) => {
-        if (!tmapModuleRef.current) return;
+        if (!tmapModule) return;
         setPathType(updatedMode);
-        await tmapModuleRef.current.togglePathMode(updatedMode);
+        await tmapModule.togglePathMode(updatedMode);
     };
 
     const handleToggleShowPath = () => {
-        if (!tmapModuleRef.current) return;
+        if (!tmapModule) return;
         toggleShowPath();
-        tmapModuleRef.current.togglePathVisibility();
+        tmapModule.togglePathVisibility();
     };
 
     useEventListeners('duration:update', (event) =>

--- a/src/features/path/path-item/PathItem.tsx
+++ b/src/features/path/path-item/PathItem.tsx
@@ -33,7 +33,7 @@ const PathItem = ({ marker, order }: PropsType) => {
     const controls = useDragControls();
     const y = useMotionValue(0);
 
-    const isSelected = selectedId === marker.id;
+    const isSelected = selectedId === marker.pinId;
 
     const handleToggleHover = (updatedStatus: boolean) => {
         if (selectedId === null) setIsHover(updatedStatus);
@@ -78,11 +78,11 @@ const PathItem = ({ marker, order }: PropsType) => {
             <div className={S.orderBox}>{order}</div>
 
             <PathControlBox
-                id={marker.id}
-                name={marker.name}
+                id={marker.pinId}
+                name={marker.pinName}
                 address={marker.address}
             />
-            <ThreeDotButton markerId={marker.id} />
+            <ThreeDotButton pinId={marker.pinId} />
         </Reorder.Item>
     );
 };

--- a/src/features/path/path-item/ThreeDotButton.tsx
+++ b/src/features/path/path-item/ThreeDotButton.tsx
@@ -14,19 +14,23 @@ interface PropsType {
 }
 
 const ThreeDotButton = ({ markerId }: PropsType) => {
-    const { tmapModuleRef } = useTmap();
+    const { tmapModule } = useTmap();
 
     const initPinHided =
-        !!tmapModuleRef.current?.getMarkerById(markerId)?.isHidden;
+        !!tmapModule?.getMarkerById(markerId)?.isHidden;
 
     const { value: isPinHided, toggle: togglePinHided } =
         useDisclosure(initPinHided);
 
     const handlePinHide = () => {
-        if (!tmapModuleRef.current) return;
-        tmapModuleRef.current.toggleMarkerHiddenState(markerId);
+        if (!tmapModule) return;
+        tmapModule.toggleMarkerHiddenState(markerId);
         togglePinHided();
     };
+
+    const handlePinRemove = () => {
+        tmapModule?.removeMarker(markerId);
+    }
 
     return (
         <PopOver>
@@ -51,7 +55,7 @@ const ThreeDotButton = ({ markerId }: PropsType) => {
                     <p className={S.text}>장소명 수정</p>
                 </PopOver.Item>
 
-                <PopOver.Item>
+                <PopOver.Item onClick={handlePinRemove}>
                     <TrashCanIcon />
                     <p className={S.text}>장소 삭제</p>
                 </PopOver.Item>

--- a/src/features/path/path-item/ThreeDotButton.tsx
+++ b/src/features/path/path-item/ThreeDotButton.tsx
@@ -17,7 +17,7 @@ const ThreeDotButton = ({ markerId }: PropsType) => {
     const { tmapModuleRef } = useTmap();
 
     const initPinHided =
-        !!tmapModuleRef.current?.getMarkerInfoFromId(markerId)?.isHidden;
+        !!tmapModuleRef.current?.getMarkerById(markerId)?.isHidden;
 
     const { value: isPinHided, toggle: togglePinHided } =
         useDisclosure(initPinHided);

--- a/src/features/path/path-item/ThreeDotButton.tsx
+++ b/src/features/path/path-item/ThreeDotButton.tsx
@@ -13,28 +13,28 @@ import { useTmap } from '@/hooks/useTmap';
 import * as S from './ThreeDotButton.css';
 
 interface PropsType {
-    markerId: string;
+    pinId: string;
 }
 
-const ThreeDotButton = ({ markerId }: PropsType) => {
+const ThreeDotButton = ({ pinId }: PropsType) => {
     const { courseId } = useParams();
     const { tmapModule } = useTmap();
 
     const stompClient = useSocket(Number(courseId));
 
-    const initPinHided = !!tmapModule?.getMarkerById(markerId)?.isHidden;
+    const initPinHided = !!tmapModule?.getMarkerById(pinId)?.isHidden;
 
     const { value: isPinHided, toggle: togglePinHided } =
         useDisclosure(initPinHided);
 
     const handlePinHide = () => {
         if (!tmapModule) return;
-        tmapModule.toggleMarkerHiddenState(markerId);
+        tmapModule.toggleMarkerHiddenState(pinId);
         togglePinHided();
     };
 
     const handlePinRemove = () => {
-        stompClient.removePin({ pinId: markerId })
+        stompClient.removePin({ pinId })
     };
 
     return (

--- a/src/features/path/path-item/ThreeDotButton.tsx
+++ b/src/features/path/path-item/ThreeDotButton.tsx
@@ -1,3 +1,5 @@
+import { useParams } from 'react-router-dom';
+
 import EditIcon from '@/assets/icons/edit.svg?react';
 import EyeClosedIcon from '@/assets/icons/eyeClosed.svg?react';
 import EyeOpenedIcon from '@/assets/icons/eyeOpened.svg?react';
@@ -5,6 +7,7 @@ import ThreeDotIcon from '@/assets/icons/threeDot.svg?react';
 import TrashCanIcon from '@/assets/icons/trashCan.svg?react';
 import PopOver from '@/components/pop-over';
 import { useDisclosure } from '@/hooks/useDisclosure';
+import { useSocket } from '@/hooks/useSocket';
 import { useTmap } from '@/hooks/useTmap';
 
 import * as S from './ThreeDotButton.css';
@@ -14,10 +17,12 @@ interface PropsType {
 }
 
 const ThreeDotButton = ({ markerId }: PropsType) => {
+    const { courseId } = useParams();
     const { tmapModule } = useTmap();
 
-    const initPinHided =
-        !!tmapModule?.getMarkerById(markerId)?.isHidden;
+    const stompClient = useSocket(Number(courseId));
+
+    const initPinHided = !!tmapModule?.getMarkerById(markerId)?.isHidden;
 
     const { value: isPinHided, toggle: togglePinHided } =
         useDisclosure(initPinHided);
@@ -29,8 +34,8 @@ const ThreeDotButton = ({ markerId }: PropsType) => {
     };
 
     const handlePinRemove = () => {
-        tmapModule?.removeMarker(markerId);
-    }
+        stompClient.removePin({ pinId: markerId })
+    };
 
     return (
         <PopOver>

--- a/src/features/path/path-view/PathView.tsx
+++ b/src/features/path/path-view/PathView.tsx
@@ -21,7 +21,7 @@ const REORDER_DELAY = 330;
 const PathView = () => {
     const { courseId } = useParams();
     const { debounce } = useDebounce();
-    const { isMapLoaded, tmapModule } = useTmap();
+    const { tmapModule } = useTmap();
     const stompClient = useSocket(Number(courseId));
 
     const {
@@ -43,13 +43,11 @@ const PathView = () => {
     useEventListeners('marker:create', (event) => {
         if (!courseId) return;
         const updatedMarkers = [...markers, event.detail];
-        updatedMarkers.sort((a, b) => a.sequence - b.sequence);
         setMarkers(updatedMarkers);
     });
 
     useEventListeners('marker:remove', (event) => {
         if (!courseId) return;
-        console.log(event.detail, 'remove');
         stompClient.removePin({ pinId: event.detail });
     });
 
@@ -70,7 +68,7 @@ const PathView = () => {
             )
             .filter((marker): marker is MarkerType => !!marker);
         setMarkers(initMarkerList);
-    }, [pinResList, tmapModule, isMapLoaded]);
+    }, [pinResList, tmapModule]);
 
     const debouncedModifyMarker = debounce((newOrder: MarkerType[]) => {
         if (!tmapModule) return;

--- a/src/features/path/path-view/PathView.tsx
+++ b/src/features/path/path-view/PathView.tsx
@@ -40,9 +40,11 @@ const PathView = () => {
     });
 
     useEventListeners('infoWindow:revert', (event) => {
+        console.log(event.detail);
         const removedMarker = tmapModule?.getMarkerBySequence(event.detail);
+        console.log(removedMarker);
         if (!removedMarker) return;
-        stompClient.removePin({ pinId: removedMarker.id });
+        stompClient.removePin({ pinId: removedMarker.pinId });
     });
 
     useEventListeners('marker:create', (event) => {
@@ -52,7 +54,7 @@ const PathView = () => {
 
     useEventListeners('marker:remove', (event) => {
         const updatedMarkers = markers.filter(
-            (marker) => marker.id !== event.detail,
+            (marker) => marker.pinId !== event.detail,
         );
         setMarkers(updatedMarkers);
     });
@@ -60,19 +62,10 @@ const PathView = () => {
     useEffect(() => {
         if (!tmapModule) return;
 
-        const initMarkerList: MarkerType[] = pinResList
-            .map(({ pinName, pinId, address, latitude, longitude, sequence }) =>
-                tmapModule.createMarker({
-                    name: pinName,
-                    originName: pinName,
-                    address,
-                    id: pinId,
-                    lat: String(latitude),
-                    lng: String(longitude),
-                    sequence,
-                }),
-            )
+        const initMarkerList = pinResList
+            .map((pin) => tmapModule.createMarker(pin))
             .filter((marker): marker is MarkerType => !!marker);
+            
         setMarkers(initMarkerList);
     }, [pinResList, tmapModule]);
 
@@ -107,7 +100,7 @@ const PathView = () => {
             >
                 {markers.map((marker, index) => (
                     <PathItem
-                        key={marker.id}
+                        key={marker.pinId}
                         marker={marker}
                         order={index + 1}
                     />

--- a/src/features/path/path-view/PathView.tsx
+++ b/src/features/path/path-view/PathView.tsx
@@ -33,7 +33,6 @@ const PathView = () => {
 
     useEventListeners('infoWindow:confirm', (event) => {
         if (!courseId) return;
-        console.log('created InfoWindow', event.detail);
         stompClient.addPin({
             courseId: Number(courseId),
             ...event.detail,
@@ -41,7 +40,9 @@ const PathView = () => {
     });
 
     useEventListeners('infoWindow:revert', (event) => {
-        stompClient.removePin({ pinId: event.detail });
+        const removedMarker = tmapModule?.getMarkerBySequence(event.detail);
+        if (!removedMarker) return;
+        stompClient.removePin({ pinId: removedMarker.id });
     });
 
     useEventListeners('marker:create', (event) => {

--- a/src/features/path/path-view/PathView.tsx
+++ b/src/features/path/path-view/PathView.tsx
@@ -40,15 +40,20 @@ const PathView = () => {
         });
     });
 
+    useEventListeners('infoWindow:revert', (event) => {
+        stompClient.removePin({ pinId: event.detail });
+    });
+
     useEventListeners('marker:create', (event) => {
-        if (!courseId) return;
         const updatedMarkers = [...markers, event.detail];
         setMarkers(updatedMarkers);
     });
 
     useEventListeners('marker:remove', (event) => {
-        if (!courseId) return;
-        stompClient.removePin({ pinId: event.detail });
+        const updatedMarkers = markers.filter(
+            (marker) => marker.id !== event.detail,
+        );
+        setMarkers(updatedMarkers);
     });
 
     useEffect(() => {

--- a/src/features/search/search-result-tab/SearchResultTab.tsx
+++ b/src/features/search/search-result-tab/SearchResultTab.tsx
@@ -21,9 +21,9 @@ const SearchResultTab = ({ name, address, lat, lng, id }: PropsType) => {
     const { tmapModuleRef } = useTmap();
 
     const tmapModule = tmapModuleRef.current;
-    const pinState = tmapModule?.checkIsAlreadyPinned(id);
+    const initialPinState = !!tmapModule?.getMarkerById(id);
 
-    const [isPinned, setIsPinned] = useState(pinState);
+    const [isPinned, setIsPinned] = useState(initialPinState);
 
     useEventListeners('marker:remove', (event) => {
         if (event.detail === id) setIsPinned(false);

--- a/src/features/search/search-result-tab/SearchResultTab.tsx
+++ b/src/features/search/search-result-tab/SearchResultTab.tsx
@@ -18,9 +18,8 @@ interface PropsType {
 }
 
 const SearchResultTab = ({ name, address, lat, lng, id }: PropsType) => {
-    const { tmapModuleRef } = useTmap();
+    const { tmapModule } = useTmap();
 
-    const tmapModule = tmapModuleRef.current;
     const initialPinState = !!tmapModule?.getMarkerById(id);
 
     const [isPinned, setIsPinned] = useState(initialPinState);

--- a/src/features/search/search-results-container/SearchResultsContainer.tsx
+++ b/src/features/search/search-results-container/SearchResultsContainer.tsx
@@ -41,13 +41,13 @@ const SearchResultsContainer = () => {
                     ({ pkey, name, newAddressList, noorLat, noorLon }) => (
                         <SearchResultTab
                             key={pkey}
-                            id={pkey}
+                            pKey={pkey}
                             name={name}
                             address={
                                 newAddressList.newAddress[0].fullAddressRoad
                             }
-                            lat={noorLat}
-                            lng={noorLon}
+                            latitude={noorLat}
+                            longitude={noorLon}
                         />
                     ),
                 )

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -1,23 +1,16 @@
-import { useEffect, useRef } from 'react';
+import { useContext } from 'react';
 
-import { Client as StompClient } from '@stomp/stompjs';
-
-import type { ApiResponseType } from '@/apis/api';
-import type {
-    CourseSocketPubType,
-    CourseSocketSubType,
-} from '@/apis/course/type';
-import { useTmap } from '@/hooks/useTmap';
+import type { CourseSocketPubType } from '@/apis/course/type';
+import { StompContext } from '@/utils/socket/StompClientProvider';
 
 export const useSocket = (courseId: number) => {
-    const stompClient = useRef<StompClient | null>(null);
-    const { tmapModule } = useTmap();
+    const { stompClient } = useContext(StompContext);
 
     const modifyPinName = ({
         pinId,
         pinName,
     }: CourseSocketPubType['modifyName']) => {
-        stompClient.current?.publish({
+        stompClient?.publish({
             destination: `/pub/${courseId}/pin/modification/name`,
             body: JSON.stringify({
                 pinId,
@@ -30,7 +23,7 @@ export const useSocket = (courseId: number) => {
         pinId,
         sequence,
     }: CourseSocketPubType['modifySequence']) => {
-        stompClient.current?.publish({
+        stompClient?.publish({
             destination: `/pub/${courseId}/pin/modification/sequence`,
             body: JSON.stringify({
                 pinId,
@@ -48,7 +41,7 @@ export const useSocket = (courseId: number) => {
         sequence,
         address,
     }: CourseSocketPubType['addition']) => {
-        stompClient.current?.publish({
+        stompClient?.publish({
             destination: `/pub/${courseId}/pin/addition`,
             body: JSON.stringify({
                 courseId,
@@ -63,87 +56,13 @@ export const useSocket = (courseId: number) => {
     };
 
     const removePin = ({ pinId }: CourseSocketPubType['removal']) => {
-        stompClient.current?.publish({
+        stompClient?.publish({
             destination: `/pub/${courseId}/pin/removal`,
             body: JSON.stringify({
-                courseId,
                 pinId,
             }),
         });
     };
-
-    useEffect(() => {
-        const stomp = new StompClient({
-            brokerURL: `wss://api.audy-gakka.com/course/${courseId}`,
-            onConnect: () => {
-                console.log('Connected to the broker');
-
-                stomp.subscribe(`/sub/${courseId}/pin/addition`, (message) => {
-                    const {
-                        data: newMarker,
-                    }: ApiResponseType<CourseSocketSubType['addition']> =
-                        JSON.parse(message.body);
-
-                    tmapModule?.createMarker({
-                        id: newMarker.pinId,
-                        name: newMarker.pinName,
-                        originName: newMarker.originName,
-                        address: newMarker.address,
-                        lat: String(newMarker.latitude),
-                        lng: String(newMarker.longitude),
-                    });
-                });
-
-                stomp.subscribe(
-                    `/sub/${courseId}/pin/modification/name`,
-                    (message) => {
-                        if (!tmapModule) return;
-                        const {
-                            data: { pinId, pinName },
-                        }: ApiResponseType<CourseSocketSubType['modifyName']> =
-                            JSON.parse(message.body);
-                        console.log(pinId, pinName); // TODO : TMapModule 에서 Marker 에 Sequence 개념 도입 이후 수정 예정
-                    },
-                );
-
-                stomp.subscribe(
-                    `/sub/${courseId}/pin/modification/sequence`,
-                    (message) => {
-                        if (!tmapModule) return;
-                        const {
-                            data: { pinId, sequence },
-                        }: ApiResponseType<
-                            CourseSocketSubType['modifySequence']
-                        > = JSON.parse(message.body);
-                        console.log(pinId, sequence); // TODO : TMapModule 에서 Marker 에 Sequence 개념 도입 이후 수정 예정
-                    },
-                );
-
-                stomp.subscribe(`/sub/${courseId}/pin/removal`, (message) => {
-                    if (!tmapModule) return;
-                    console.log('remove from socket', message.body);
-                    const { pinId }: CourseSocketSubType['removal'] =
-                        JSON.parse(message.body);
-                    tmapModule.removeMarker(pinId);
-                });
-            },
-            onDisconnect: () => {
-                console.log('Disconnected from the broker');
-                stomp.deactivate();
-            },
-            onStompError: (frame) => {
-                console.log('Broker reported error:', frame);
-                stomp.deactivate();
-            },
-        });
-
-        stomp.activate();
-        stompClient.current = stomp;
-
-        return () => {
-            stompClient.current?.deactivate();
-        };
-    }, [courseId, tmapModule]);
 
     return {
         modifyPinName,

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -1,7 +1,7 @@
 import { useContext } from 'react';
 
 import type { CourseSocketPubType } from '@/apis/course/type';
-import { StompContext } from '@/utils/socket/StompClientProvider';
+import { StompContext } from '@/utils/socket/StompProvider';
 
 export const useSocket = (courseId: number) => {
     const { stompClient } = useContext(StompContext);
@@ -10,7 +10,7 @@ export const useSocket = (courseId: number) => {
         pinId,
         pinName,
     }: CourseSocketPubType['modifyName']) => {
-        stompClient?.publish({
+        stompClient.current?.publish({
             destination: `/pub/${courseId}/pin/modification/name`,
             body: JSON.stringify({
                 pinId,
@@ -23,7 +23,7 @@ export const useSocket = (courseId: number) => {
         pinId,
         sequence,
     }: CourseSocketPubType['modifySequence']) => {
-        stompClient?.publish({
+        stompClient.current?.publish({
             destination: `/pub/${courseId}/pin/modification/sequence`,
             body: JSON.stringify({
                 pinId,
@@ -41,7 +41,7 @@ export const useSocket = (courseId: number) => {
         sequence,
         address,
     }: CourseSocketPubType['addition']) => {
-        stompClient?.publish({
+        stompClient.current?.publish({
             destination: `/pub/${courseId}/pin/addition`,
             body: JSON.stringify({
                 courseId,
@@ -56,7 +56,7 @@ export const useSocket = (courseId: number) => {
     };
 
     const removePin = ({ pinId }: CourseSocketPubType['removal']) => {
-        stompClient?.publish({
+        stompClient.current?.publish({
             destination: `/pub/${courseId}/pin/removal`,
             body: JSON.stringify({
                 pinId,

--- a/src/hooks/useTmap.ts
+++ b/src/hooks/useTmap.ts
@@ -6,6 +6,6 @@ import { TmapContext } from '@/utils/tmap/TmapModuleProvider';
  * TmapProvider 로부터 Module, MapContainer RefObject 를 인계 받는 Hook useTmap
  */
 export const useTmap = () => {
-    const { tmapModule, mapContainerRef, isMapLoaded } = useContext(TmapContext);
-    return { tmapModule, mapContainerRef, isMapLoaded };
+    const { tmapModule, mapContainerRef } = useContext(TmapContext);
+    return { tmapModule, mapContainerRef };
 };

--- a/src/hooks/useTmap.ts
+++ b/src/hooks/useTmap.ts
@@ -6,6 +6,6 @@ import { TmapContext } from '@/utils/tmap/TmapModuleProvider';
  * TmapProvider 로부터 Module, MapContainer RefObject 를 인계 받는 Hook useTmap
  */
 export const useTmap = () => {
-    const { tmapModuleRef, mapContainerRef } = useContext(TmapContext);
-    return { mapContainerRef, tmapModuleRef };
+    const { tmapModule, mapContainerRef, isMapLoaded } = useContext(TmapContext);
+    return { tmapModule, mapContainerRef, isMapLoaded };
 };

--- a/src/pages/course/CoursePage.tsx
+++ b/src/pages/course/CoursePage.tsx
@@ -7,6 +7,7 @@ import SearchBar from '@/features/search/search-bar';
 import { SearchContextProvider } from '@/features/search/search-context';
 import SearchResultsContainer from '@/features/search/search-results-container';
 import { useTmap } from '@/hooks/useTmap';
+import { StompProvider } from '@/utils/socket/StompClientProvider';
 
 import * as S from './CoursePage.css';
 
@@ -14,7 +15,7 @@ function CoursePage() {
     const { mapContainerRef } = useTmap();
 
     return (
-        <>
+        <StompProvider>
             <GlobalNavigationBar />
 
             <div className={S.wrapper}>
@@ -31,7 +32,7 @@ function CoursePage() {
                     <FloatMenu />
                 </div>
             </div>
-        </>
+        </StompProvider>
     );
 }
 

--- a/src/pages/course/CoursePage.tsx
+++ b/src/pages/course/CoursePage.tsx
@@ -7,7 +7,7 @@ import SearchBar from '@/features/search/search-bar';
 import { SearchContextProvider } from '@/features/search/search-context';
 import SearchResultsContainer from '@/features/search/search-results-container';
 import { useTmap } from '@/hooks/useTmap';
-import { StompProvider } from '@/utils/socket/StompClientProvider';
+import { StompProvider } from '@/utils/socket/StompProvider';
 
 import * as S from './CoursePage.css';
 

--- a/src/types/course.ts
+++ b/src/types/course.ts
@@ -1,3 +1,4 @@
+import type { EditorType } from './editor';
 import type { PinType } from './map';
 
 export interface CourseInformationType {
@@ -19,7 +20,10 @@ export interface CourseType {
 export interface CourseDetailType {
     courseId: number;
     courseName: string;
-    pinList: PinType[];
+    editorCnt: number;
+    editorGetResList: EditorType[],
+    pinCnt: number;
+    pinResList: PinType[];
 }
 
 export type CourseTabType = 'allCourse' | 'myCourse' | 'invitedCourse';

--- a/src/types/editor.ts
+++ b/src/types/editor.ts
@@ -1,0 +1,6 @@
+export interface EditorType {
+    imageUrl: string;
+    role: "MEMBER" | "OWNER";
+    userId: number;
+    userName: string;
+}

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -2,9 +2,10 @@
 export type PathModeType = 'Pedestrian' | 'Vehicle';
 
 export interface MarkerType {
-    marker: typeof window.Tmapv3.Marker;
+    instance: typeof window.Tmapv3.Marker;
     name: string;
     originName: string;
+    sequence: number;
     address: string;
     id: string;
     lat: string;

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -5,7 +5,7 @@ export interface MarkerType {
     instance: typeof window.Tmapv3.Marker;
     name: string;
     originName: string;
-    sequence: number;
+    sequence: string;
     address: string;
     id: string;
     lat: string;
@@ -20,5 +20,5 @@ export interface PinType {
     latitude: number;
     longitude: number;
     address: string;
-    sequence: number;
+    sequence: string;
 }

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -1,24 +1,17 @@
 /** 지도에서 나타내는 경로의 타입 (보행자 | 자동차) */
 export type PathModeType = 'Pedestrian' | 'Vehicle';
 
-export interface MarkerType {
-    instance: typeof window.Tmapv3.Marker;
-    name: string;
-    originName: string;
-    sequence: string;
-    address: string;
-    id: string;
-    lat: string;
-    lng: string;
-    isHidden: boolean;
-}
-
 export interface PinType {
     pinId: string;
     pinName: string;
     originName: string;
-    latitude: number;
-    longitude: number;
+    latitude: string;
+    longitude: string;
     address: string;
     sequence: string;
+}
+
+export interface MarkerType extends PinType {
+    isHidden: boolean;
+    pKey?: string; // NOTE : 검색으로 찾은 장소를 식별하기 위한 값
 }

--- a/src/utils/socket/StompClientProvider.tsx
+++ b/src/utils/socket/StompClientProvider.tsx
@@ -1,0 +1,105 @@
+import type { PropsWithChildren } from 'react';
+import { useEffect, useState, createContext } from 'react';
+
+import { Client as StompClient } from '@stomp/stompjs';
+
+import type { ApiResponseType } from '@/apis/api';
+import type {
+    CourseSocketSubType,
+} from '@/apis/course/type';
+import { useTmap } from '@/hooks/useTmap';
+import { useParams } from 'react-router-dom';
+
+interface StompProviderType {
+    stompClient: StompClient | null;
+}
+
+export const StompContext = createContext<StompProviderType>(
+    {} as StompProviderType,
+);
+
+/**
+ * StompClient 를 생성하여 주입하는 Provider StompProvider
+ */
+export const StompProvider = ({children}: PropsWithChildren) => {
+    const [stompClient, setStompClient] = useState<StompClient | null>(null);
+    const { courseId } = useParams();
+    const { tmapModule } = useTmap();
+
+    useEffect(() => {
+        if (stompClient || !courseId) return;
+
+        const stomp = new StompClient({
+            brokerURL: `wss://api.audy-gakka.com/course/${courseId}`,
+            onConnect: () => {
+                console.log('Connected to the broker');
+
+                stomp.subscribe(`/sub/${courseId}/pin/addition`, (message) => {
+                    const {
+                        data: newMarker,
+                    }: ApiResponseType<CourseSocketSubType['addition']> =
+                        JSON.parse(message.body);
+
+                    tmapModule?.createMarker({
+                        id: newMarker.pinId,
+                        name: newMarker.pinName,
+                        originName: newMarker.originName,
+                        address: newMarker.address,
+                        lat: String(newMarker.latitude),
+                        lng: String(newMarker.longitude),
+                    });
+                });
+
+                stomp.subscribe(
+                    `/sub/${courseId}/pin/modification/name`,
+                    (message) => {
+                        const {
+                            data: { pinId, pinName },
+                        }: ApiResponseType<CourseSocketSubType['modifyName']> =
+                            JSON.parse(message.body);
+                        console.log(pinId, pinName); // TODO : TMapModule 에서 Marker 에 Sequence 개념 도입 이후 수정 예정
+                    },
+                );
+
+                stomp.subscribe(
+                    `/sub/${courseId}/pin/modification/sequence`,
+                    (message) => {
+                        const {
+                            data: { pinId, sequence },
+                        }: ApiResponseType<
+                            CourseSocketSubType['modifySequence']
+                        > = JSON.parse(message.body);
+                        console.log(pinId, sequence); // TODO : TMapModule 에서 Marker 에 Sequence 개념 도입 이후 수정 예정
+                    },
+                );
+
+                stomp.subscribe(`/sub/${courseId}/pin/removal`, (message) => {
+                    if (!tmapModule) return;
+                    console.log('remove from socket', message.body);
+                    const { pinId }: CourseSocketSubType['removal'] =
+                        JSON.parse(message.body);
+                    tmapModule.removeMarker(pinId);
+                });
+            },
+            onDisconnect: () => {
+                console.log('Disconnected from the broker');
+                stomp.deactivate();
+            },
+            onStompError: (frame) => {
+                console.log('Broker reported error:', frame);
+                stomp.deactivate();
+            },
+        });
+
+        stomp.activate();
+        setStompClient(stomp);
+    }, [courseId, stompClient, tmapModule]);
+
+    return (
+        <StompContext.Provider
+            value={{ stompClient }}
+        >
+            {children}
+        </StompContext.Provider>
+    );
+};

--- a/src/utils/socket/StompProvider.tsx
+++ b/src/utils/socket/StompProvider.tsx
@@ -25,7 +25,7 @@ export const StompProvider = ({ children }: PropsWithChildren) => {
     const { tmapModule } = useContext(TmapContext);
 
     useEffect(() => {
-        if (stompClient.current) return;
+        if (stompClient.current || !tmapModule) return;
 
         const stomp = new StompClient({
             brokerURL: `wss://api.audy-gakka.com/course/${courseId}`,
@@ -38,14 +38,7 @@ export const StompProvider = ({ children }: PropsWithChildren) => {
                     }: ApiResponseType<CourseSocketSubType['addition']> =
                         JSON.parse(message.body);
 
-                    tmapModule?.createMarker({
-                        id: newMarker.pinId,
-                        name: newMarker.pinName,
-                        originName: newMarker.originName,
-                        address: newMarker.address,
-                        lat: String(newMarker.latitude),
-                        lng: String(newMarker.longitude),
-                    });
+                    tmapModule?.createMarker(newMarker);
                 });
 
                 stomp.subscribe(

--- a/src/utils/socket/StompProvider.tsx
+++ b/src/utils/socket/StompProvider.tsx
@@ -1,4 +1,4 @@
-import type { PropsWithChildren, MutableRefObject } from 'react';
+import type { MutableRefObject, PropsWithChildren } from 'react';
 import { createContext, useContext, useEffect, useMemo, useRef } from 'react';
 
 import { Client as StompClient } from '@stomp/stompjs';
@@ -72,11 +72,12 @@ export const StompProvider = ({ children }: PropsWithChildren) => {
                 );
 
                 stomp.subscribe(`/sub/${courseId}/pin/removal`, (message) => {
-                    if (!tmapModule) return;
-                    console.log('remove from socket', message.body);
-                    const { pinId }: CourseSocketSubType['removal'] =
+                    const {
+                        data: { pinId },
+                    }: ApiResponseType<CourseSocketSubType['removal']> =
                         JSON.parse(message.body);
-                    tmapModule.removeMarker(pinId);
+
+                    tmapModule?.removeMarker(pinId);
                 });
             },
             onDisconnect: () => {

--- a/src/utils/tmap/TmapModuleProvider.tsx
+++ b/src/utils/tmap/TmapModuleProvider.tsx
@@ -1,5 +1,5 @@
 import type { MutableRefObject, PropsWithChildren } from 'react';
-import { createContext, useEffect, useRef, useState } from 'react';
+import { createContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { useLocation } from 'react-router-dom';
 
@@ -47,16 +47,22 @@ export const TmapProvider = ({
             lng,
         });
 
+        console.log(mapContainerRef.current);
         setTmapModule(tmapModuleInstance);
 
         return () => setTmapModule(null);
     }, [height, lat, lng, mapId, width, zoom, pathname]);
 
+    const value = useMemo(
+        () => ({
+            tmapModule,
+            mapContainerRef,
+        }),
+        [tmapModule],
+    );
+
     return (
-        <TmapContext.Provider
-            value={{ tmapModule, mapContainerRef }}
-            key={pathname}
-        >
+        <TmapContext.Provider value={value} key={pathname}>
             {children}
         </TmapContext.Provider>
     );

--- a/src/utils/tmap/TmapModuleProvider.tsx
+++ b/src/utils/tmap/TmapModuleProvider.tsx
@@ -47,7 +47,6 @@ export const TmapProvider = ({
             lng,
         });
 
-        console.log(mapContainerRef.current);
         setTmapModule(tmapModuleInstance);
 
         return () => setTmapModule(null);

--- a/src/utils/tmap/TmapModuleProvider.tsx
+++ b/src/utils/tmap/TmapModuleProvider.tsx
@@ -8,7 +8,6 @@ import { TMapModule, type TmapConstructorType } from './tmapModule';
 interface TmapProviderType {
     mapContainerRef: MutableRefObject<HTMLDivElement | null>;
     tmapModule: TMapModule | null;
-    isMapLoaded: boolean;
 }
 
 export const TmapContext = createContext<TmapProviderType>(
@@ -29,7 +28,6 @@ export const TmapProvider = ({
     lng,
     children,
 }: PropsType) => {
-    const [isMapLoaded, setIsMapLoaded] = useState(false);
     const [tmapModule, setTmapModule] = useState<TMapModule | null>(null);
 
     const mapContainerRef = useRef<HTMLDivElement | null>(null);
@@ -50,25 +48,13 @@ export const TmapProvider = ({
         });
 
         setTmapModule(tmapModuleInstance);
-        setIsMapLoaded(true);
 
-        return () => {
-            setTmapModule(null);
-            setIsMapLoaded(false);
-        };
-    }, [
-        height,
-        lat,
-        lng,
-        mapId,
-        width,
-        zoom,
-        isMapLoaded,
-    ]);
+        return () => setTmapModule(null);
+    }, [height, lat, lng, mapId, width, zoom, pathname]);
 
     return (
         <TmapContext.Provider
-            value={{ isMapLoaded, tmapModule, mapContainerRef }}
+            value={{ tmapModule, mapContainerRef }}
             key={pathname}
         >
             {children}

--- a/src/utils/tmap/TmapModuleProvider.tsx
+++ b/src/utils/tmap/TmapModuleProvider.tsx
@@ -1,5 +1,5 @@
 import type { MutableRefObject, PropsWithChildren } from 'react';
-import { createContext, useEffect, useRef } from 'react';
+import { createContext, useEffect, useRef, useState } from 'react';
 
 import { useLocation } from 'react-router-dom';
 
@@ -7,7 +7,8 @@ import { TMapModule, type TmapConstructorType } from './tmapModule';
 
 interface TmapProviderType {
     mapContainerRef: MutableRefObject<HTMLDivElement | null>;
-    tmapModuleRef: MutableRefObject<TMapModule | null>;
+    tmapModule: TMapModule | null;
+    isMapLoaded: boolean;
 }
 
 export const TmapContext = createContext<TmapProviderType>(
@@ -28,8 +29,10 @@ export const TmapProvider = ({
     lng,
     children,
 }: PropsType) => {
+    const [isMapLoaded, setIsMapLoaded] = useState(false);
+    const [tmapModule, setTmapModule] = useState<TMapModule | null>(null);
+
     const mapContainerRef = useRef<HTMLDivElement | null>(null);
-    const tmapModuleRef = useRef<TMapModule | null>(null);
 
     const { pathname } = useLocation();
 
@@ -37,8 +40,7 @@ export const TmapProvider = ({
         if (!mapContainerRef.current) return;
 
         mapContainerRef.current.id = mapId;
-
-        tmapModuleRef.current = new TMapModule({
+        const tmapModuleInstance = new TMapModule({
             mapId,
             width,
             height,
@@ -47,14 +49,26 @@ export const TmapProvider = ({
             lng,
         });
 
+        setTmapModule(tmapModuleInstance);
+        setIsMapLoaded(true);
+
         return () => {
-            tmapModuleRef.current = null;
+            setTmapModule(null);
+            setIsMapLoaded(false);
         };
-    }, [height, lat, lng, mapId, width, zoom, pathname]);
+    }, [
+        height,
+        lat,
+        lng,
+        mapId,
+        width,
+        zoom,
+        isMapLoaded,
+    ]);
 
     return (
         <TmapContext.Provider
-            value={{ mapContainerRef, tmapModuleRef }}
+            value={{ isMapLoaded, tmapModule, mapContainerRef }}
             key={pathname}
         >
             {children}


### PR DESCRIPTION
### 📃 변경사항  
- WebSocket - TmapModule - React 간의 연계가 정상적으로 이루어지도록 로직을 대거 개선했습니다.
- React 컴포넌트 혹은 Tmap 내부에서 마커 추가 및 삭제 시, WebSocket Publish 를 먼저 진행하도록 했습니다.
- 이후 Websocket subscribe 를 통해 받은 데이터를 기반으로 지도를 수정하도록 플로우를 수정했습니다.
- 장소 검색으로 나온 곳을 코스에 추가 혹은 삭제할 수 있도록 기능을 개선했습니다.

### 🫨 고민한 부분 (optional)  
- 백엔드 단에서 보낸 데이터와의 연동성을 강하게 가져가기 위해 TmapModule 내부에서 쓰이던 네이밍을 백엔드 단과 일치시켰습니다. 
- 이로 인해 많은 breaking change 를 일으켜 죄송합니다. (사안이 급하다 보니 일단 수정했습니다)
- TmapModule 이 ref 로 관리되다 보니 PathView 단에서는 실제 Tmap 이 정상적으로 작동하는 시점을 알 수 없어 서버에서 받은 pinResList 를 기반으로 뷰를 그릴 수가 없었습니다. 따라서 이를 타파하기 위해 state 로 Module 을 관리했습니다.
- StompClient 또한 coursePage 에서만 사용하도록 Context API 기반의 아키텍쳐를 도입했습니다.
- 클러스터링 기능이 의도치 않은 동작으로 인하여 임시 비활성화 처리했습니다. 빠르게 수정하도록 하겠습니다.